### PR TITLE
Add backend validation response processing to FormManager

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -58,7 +58,7 @@ title: string;
 ```ts
 cardConfig: ICardConfig;
 children?: any;
-close: () => void;
+close?: () => void;
 defaults?: object;
 form: any;
 model?: any;

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -1,6 +1,8 @@
 import React, { Component, Fragment } from 'react';
+import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import { noop } from 'lodash';
 
 import * as Antd from 'antd';
 
@@ -9,12 +11,11 @@ import { ICardConfig, IFieldSet } from '../interfaces';
 import FormFields from '../building-blocks/FormFields';
 import FormManager from '../utilities/FormManager';
 import { fillInFieldSets } from '../utilities/common';
-import { computed } from 'mobx';
 
 interface IProps {
   cardConfig: ICardConfig;
   children?: any;
-  close: () => void;
+  close?: () => void;
   defaults?: object;
   form: any;
   model?: any;
@@ -26,6 +27,10 @@ interface IProps {
 @observer
 class FormCard extends Component<IProps> {
   private formManager: FormManager;
+
+  public static defaultProps: Partial<IProps> = {
+    close: noop,
+  };
 
   public constructor (props: IProps) {
     super(props);

--- a/src/utilities/backendValidation.ts
+++ b/src/utilities/backendValidation.ts
@@ -1,0 +1,70 @@
+import { isArray, isPlainObject, extend } from 'lodash';
+
+import { varToLabel } from '@mighty-justice/utils';
+
+// Takes an API response and converts it to a string to string map
+function getFieldErrors (errors: { [key: string]: any }, prefix = '') {
+  const messages: { [key: string]: string } = {};
+  Object.keys(errors).forEach(fieldName => {
+    const fieldKey = [prefix, fieldName].filter(s => !!s).join('-');
+    let fieldErrors = errors[fieldName];
+
+    // If an array, use only the first element
+    if (isArray(fieldErrors)) {
+      fieldErrors = fieldErrors[0];
+    }
+
+    // If an object, recurse
+    if (isPlainObject(fieldErrors)) {
+      extend(messages, getFieldErrors(fieldErrors, fieldKey));
+    }
+
+    // If a simple string, you have your error
+    else {
+      messages[fieldKey] = fieldErrors;
+    }
+  });
+  return messages;
+}
+
+export default function backendValidation (fieldNames: string[], response: object) {
+  const fieldErrors = getFieldErrors(response)
+    , foundOnForm: { [key: string]: string } = {}
+    , errorMessages: Array<{ field: string, message: string }> = [];
+
+  // Try to assign error fields to form fields, falling back on generic array
+  Object.keys(fieldErrors).forEach(errorField => {
+    const message = fieldErrors[errorField];
+
+    // Check for an exact match
+    if (fieldNames.includes(errorField)) {
+      foundOnForm[errorField] = message;
+      return;
+    }
+
+    // Check just the last attribute of the error
+    if (errorField.includes('-')) {
+      const errorFieldSuffix = errorField.split('-').pop();
+      if (errorFieldSuffix && fieldNames.includes(errorFieldSuffix)) {
+        foundOnForm[errorFieldSuffix] = message;
+        return;
+      }
+    }
+
+    // Check for a more fuzzy match of the entire string
+    for (const fieldName of fieldNames) {
+      const fieldNameFlat = fieldName.toLowerCase().replace(/[^a-z]/gi, '')
+        , errorFieldFlat = errorField.toLowerCase().replace(/[^a-z]/gi, '');
+
+      if (errorFieldFlat === fieldNameFlat) {
+        foundOnForm[fieldName] = message;
+        return;
+      }
+    }
+
+    // With no form field found, add to generic array
+    errorMessages.push({ field: varToLabel(errorField), message });
+  });
+
+  return { errorMessages, foundOnForm };
+}

--- a/test/components/FormCard.test.js
+++ b/test/components/FormCard.test.js
@@ -1,0 +1,72 @@
+/* global it, describe, expect */
+
+import React from 'react';
+import faker from 'faker';
+import { Tester } from '@mighty-justice/tester';
+import * as Antd from 'antd';
+
+import { FormCard } from '../../src';
+
+function changeInput (component, value) {
+  component.simulate('focus');
+  component.simulate('change', { target: { value } });
+  component.simulate('blur');
+}
+
+describe('FormCard', () => {
+  it('Edits text', async () => {
+    const text = faker.lorem.sentence()
+      , newText = faker.lorem.sentence()
+      , title = 'testing'
+      , onSave = jest.fn().mockResolvedValue({})
+      , props = {
+        cardConfig: {
+          fieldSets: [[{ field: 'text' }]],
+          title,
+        },
+        model: { text },
+        onSave,
+      };
+
+    const tester = await new Tester(FormCard, { props }).mount();
+
+    changeInput(tester.find('input'), newText);
+
+    expect(onSave).not.toHaveBeenCalled();
+    tester.find('form').simulate('submit');
+    await tester.sleep();
+    expect(onSave).toHaveBeenCalledWith({ text: newText });
+  });
+
+  it('Maps backend errors to fields on form', async () => {
+    const nameError = faker.lorem.sentence()
+      , otherError = faker.lorem.sentence()
+      , response = { response: { data: {
+        'non_field_errors': [otherError],
+        'plaintiff': [{ 'name': [nameError] }],
+      }}}
+      , name = faker.lorem.sentence()
+      , onSave = jest.fn().mockRejectedValue(response)
+      , props = {
+        cardConfig: {
+          fieldSets: [[{ field: 'name' }]],
+          title: 'Information',
+        },
+        model: { name },
+        onSave,
+      };
+
+    spyOn(Antd.notification, 'error');
+    const tester = await new Tester(FormCard, { props }).mount();
+
+    expect(Antd.notification.error).not.toHaveBeenCalled();
+    expect(tester.text()).not.toContain(nameError);
+
+    tester.find('form').simulate('submit');
+    await tester.sleep();
+
+    expect(Antd.notification.error).toHaveBeenCalled();
+    const antErrorCall = Antd.notification.error.calls.mostRecent();
+    expect(JSON.stringify(antErrorCall)).toContain(otherError);
+  })
+});

--- a/test/utilities/backendValidation.test.js
+++ b/test/utilities/backendValidation.test.js
@@ -1,0 +1,69 @@
+/* global describe, it, expect */
+/* eslint-disable no-magic-numbers, sort-keys */
+import { has } from 'lodash';
+import faker from 'faker';
+import backendValidation from '../../src/utilities/backendValidation';
+
+const TEST_STRINGS = {};
+function getString (key) {
+  if (!has(TEST_STRINGS, key)) {
+    TEST_STRINGS[key] = faker.lorem.sentence().replace('error', '');
+  }
+  return TEST_STRINGS[key];
+}
+
+const FIELD_NAMES = [
+  'name',
+  'medicalfacility_website',
+  'medical_facility-fax',
+];
+
+const TESTING_PAIRS = [
+  {
+    RESPONSE: {},
+    FOUND_ON_FORM: {},
+    ERROR_MESSAGES: [],
+  },
+  {
+    RESPONSE: { 'name': [getString(1)] },
+    FOUND_ON_FORM: { 'name': getString(1) },
+    ERROR_MESSAGES: [],
+  },
+  {
+    RESPONSE: { 'non_field_errors': [getString(2)] },
+    FOUND_ON_FORM: {},
+    ERROR_MESSAGES: [{ field: 'Non Field Errors', message: getString(2) }],
+  },
+  {
+    RESPONSE: { 'plaintiff': [{ 'name': [getString(3)] }] },
+    FOUND_ON_FORM: { 'name': getString(3) },
+    ERROR_MESSAGES: [],
+  },
+  {
+    RESPONSE: { 'medical_facility': {'fax': [getString(4)]}},
+    FOUND_ON_FORM: { 'medical_facility-fax': getString(4) },
+    ERROR_MESSAGES: [],
+  },
+  {
+    RESPONSE: { 'medical_facility': {'website': [getString(4)]}},
+    FOUND_ON_FORM: { 'medicalfacility_website': getString(4) },
+    ERROR_MESSAGES: [],
+  },
+  {
+    RESPONSE: { 'medical_facility': {'branch': [getString(5)]}},
+    FOUND_ON_FORM: {},
+    ERROR_MESSAGES: [{ field: 'Medical Facility Branch', message: getString(5) }],
+  },
+];
+
+describe('Backend Validation', () => {
+  TESTING_PAIRS.forEach((TEST_PAIR, i) => {
+    it(`Correctly extracts backend validation messages, #${i + 1}`, async () => {
+      const { RESPONSE, FOUND_ON_FORM, ERROR_MESSAGES } = TEST_PAIR;
+      const { foundOnForm, errorMessages } = backendValidation(FIELD_NAMES, RESPONSE);
+
+      expect(foundOnForm).toEqual(FOUND_ON_FORM);
+      expect(errorMessages).toEqual(ERROR_MESSAGES);
+    });
+  });
+});


### PR DESCRIPTION
`backendValidation.ts` and associated test file  was copied exactly as it exists on V2, where it has worked beautifully for a long time, and should be mostly ignored for the purposes of this code review.

Closes https://github.com/mighty-justice/fields-ant/issues/31