### PR TITLE
Add ChildrenBefore in FormModal

### DIFF
--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -14,6 +14,7 @@ import { computed } from 'mobx';
 interface IProps {
   cardConfig: ICardConfig;
   children?: any;
+  childrenBefore?: any;
   close: () => void;
   defaults?: object;
   form: any;
@@ -73,6 +74,8 @@ class FormModal extends Component<IProps> {
         visible
       >
         <Antd.Form onSubmit={this.formManager.onSave} className='notes-form'>
+          {this.props.childrenBefore}
+
           {this.fieldSets.map((fieldSet, idx) => (
             <div key={idx}>
               <FormFields

--- a/test/components/FormModal.test.js
+++ b/test/components/FormModal.test.js
@@ -1,6 +1,5 @@
 /* global it, describe, expect */
 
-import React from 'react';
 import faker from 'faker';
 
 import { FormModal } from '../../src';
@@ -22,5 +21,22 @@ describe('FormModal', () => {
     expect(noLoading.text()).toContain(title);
     expect(noLoading.text()).toContain('Text');
     expect(noLoading.html()).toContain(text);
+  });
+
+  it('Renders children', async () => {
+    const textChildren = faker.lorem.sentence()
+      , textChildrenBefore = faker.lorem.sentence()
+      , props = {
+        cardConfig: {
+          fieldSets: [],
+          title: 'Children Modal',
+        },
+        children: textChildren,
+        childrenBefore: textChildrenBefore,
+      };
+
+    const tester = await new Tester(FormModal, { props }).mount();
+    expect(tester.text()).toContain(textChildren);
+    expect(tester.text()).toContain(textChildrenBefore);
   });
 });


### PR DESCRIPTION
This is something we have in v2, but not in fields-ant at the moment.

I need it now in the Registry and I'm sure we'll need it again in the future.