### PR TITLE
Move options functions into utils, other clean-ups

### DIFF
--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -10,32 +10,24 @@ import * as Antd from 'antd';
 
 import {
   IAntFormField,
-  IFieldConfig,
   IFieldConfigObjectSearchCreate,
+  IInjected,
+  IInputProps,
   NestedFieldSet,
 } from '../';
-
-interface IProps {
-  fieldConfig: IFieldConfig;
-  form: any;
-}
-
-interface IInjected extends IProps, IAntFormField {
-  getEndpoint: (endpoint: string) => Promise<any>;
-}
 
 const MIN_SEARCH_LENGTH = 3;
 
 @inject('getEndpoint')
 @autoBindMethods
 @observer
-class ObjectSearchCreate extends Component<IProps> {
+class ObjectSearchCreate extends Component<IInputProps> {
   @observable private isAddingNew = new SmartBool();
   @observable private options: Array<{ id: string, name: string }> = [];
   @observable private search = '';
 
   private get injected () {
-    return this.props as IInjected;
+    return this.props as IInjected & IInputProps & IAntFormField;
   }
 
   private get fieldConfig () {

--- a/src/inputs/OptionSelect.tsx
+++ b/src/inputs/OptionSelect.tsx
@@ -2,22 +2,26 @@ import React, { Component } from 'react';
 import { computed } from 'mobx';
 import { inject } from 'mobx-react';
 import * as Antd from 'antd';
-import { sortBy } from 'lodash';
 
-import { IFieldConfig, IFieldConfigOptionSelect, IOption } from '../interfaces';
+import {
+  IAntFormField,
+  IFieldConfig,
+  IFieldConfigOptionSelect,
+  IInjected,
+  IInputProps,
+  IOption,
+} from '../interfaces';
+
+import { getOptions } from '..';
 
 interface IProps {
   fieldConfig: IFieldConfig;
 }
 
-interface IInjected extends IProps {
-  getOptions: (optionType: string) => IOption[];
-}
-
 @inject('getOptions')
 class OptionSelect extends Component<IProps> {
   private get injected () {
-    return this.props as IInjected;
+    return this.props as IInjected & IInputProps & IAntFormField;
   }
 
   private get fieldConfig () {
@@ -25,18 +29,8 @@ class OptionSelect extends Component<IProps> {
   }
 
   @computed
-  private get unsortedOptions (): IOption[] {
-    const { options, optionType } = this.fieldConfig;
-
-    if (options) { return options; }
-    if (this.fieldConfig.getOptions) { return this.fieldConfig.getOptions(optionType); }
-    if (this.injected.getOptions) { return this.injected.getOptions(optionType); }
-    return [];
-  }
-
-  @computed
   private get options (): IOption[] {
-    return this.fieldConfig.sorted ? sortBy(this.unsortedOptions, 'name') : this.unsortedOptions;
+    return getOptions(this.fieldConfig, this.injected);
   }
 
   public render () {

--- a/src/inputs/OptionSelectDisplay.tsx
+++ b/src/inputs/OptionSelectDisplay.tsx
@@ -3,15 +3,18 @@ import autoBindMethods from 'class-autobind-decorator';
 import { inject, observer } from 'mobx-react';
 import { isArray } from 'lodash';
 
-import { IFieldConfigOptionSelect, IOption } from '../interfaces';
+import {
+  IFieldConfig,
+  IFieldConfigOptionSelect,
+  IInjected,
+  IOption,
+} from '../interfaces';
+import { computed } from 'mobx';
+import { getOptions } from '../index';
 
 interface IProps {
-  fieldConfig: { options?: any[], optionType?: string };
+  fieldConfig: IFieldConfig;
   value: any;
-}
-
-interface IInjected extends IProps {
-  getOptions: (optionType: string) => IOption[];
 }
 
 @inject('getOptions')
@@ -19,20 +22,16 @@ interface IInjected extends IProps {
 @observer
 class OptionSelectDisplay extends Component<IProps> {
   private get injected () {
-    return this.props as IInjected;
+    return this.props as IInjected & IProps;
   }
 
   private get fieldConfig () {
     return this.props.fieldConfig as IFieldConfigOptionSelect;
   }
 
+  @computed
   private get options (): IOption[] {
-    const { options, optionType } = this.fieldConfig;
-
-    if (options) { return options; }
-    if (this.fieldConfig.getOptions) { return this.fieldConfig.getOptions(optionType); }
-    if (this.injected.getOptions) { return this.injected.getOptions(optionType); }
-    return [];
+    return getOptions(this.fieldConfig, this.injected);
   }
 
   public render () {

--- a/src/inputs/OptionSelectDisplay.tsx
+++ b/src/inputs/OptionSelectDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import autoBindMethods from 'class-autobind-decorator';
+import { computed } from 'mobx';
 import { inject, observer } from 'mobx-react';
+import autoBindMethods from 'class-autobind-decorator';
 import { isArray } from 'lodash';
 
 import {
@@ -9,8 +10,8 @@ import {
   IInjected,
   IOption,
 } from '../interfaces';
-import { computed } from 'mobx';
-import { getOptions } from '../index';
+
+import { getOptions } from '..';
 
 interface IProps {
   fieldConfig: IFieldConfig;

--- a/src/inputs/RadioGroup.tsx
+++ b/src/inputs/RadioGroup.tsx
@@ -2,40 +2,33 @@ import React, { Component } from 'react';
 import * as Antd from 'antd';
 import autoBindMethods from 'class-autobind-decorator';
 import { inject, observer } from 'mobx-react';
-import { IFieldConfig, IFieldConfigOptionSelect, IOption } from '../interfaces';
-import { sortBy } from 'lodash';
 
-interface IProps {
-  fieldConfig: IFieldConfig;
-}
+import {
+  IAntFormField,
+  IFieldConfigOptionSelect,
+  IInjected,
+  IInputProps,
+  IOption,
+} from '../interfaces';
 
-interface IInjected extends IProps {
-  getOptions: (optionType: string) => IOption[];
-}
+import { getOptions } from '..';
+import { computed } from 'mobx';
 
 @inject('getOptions')
 @autoBindMethods
 @observer
-class RadioGroup extends Component<IProps> {
+class RadioGroup extends Component<IInputProps> {
   private get injected () {
-    return this.props as IInjected;
+    return this.props as IInjected & IInputProps & IAntFormField;
   }
 
   private get fieldConfig () {
     return this.props.fieldConfig as IFieldConfigOptionSelect;
   }
 
-  private get unsortedOptions (): IOption[] {
-    const { options, optionType } = this.fieldConfig;
-
-    if (options) { return options; }
-    if (this.fieldConfig.getOptions) { return this.fieldConfig.getOptions(optionType); }
-    if (this.injected.getOptions) { return this.injected.getOptions(optionType); }
-    return [];
-  }
-
+  @computed
   private get options (): IOption[] {
-    return this.fieldConfig.sorted ? sortBy(this.unsortedOptions, 'name') : this.unsortedOptions;
+    return getOptions(this.fieldConfig, this.injected);
   }
 
   public render () {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -99,3 +99,15 @@ export interface ICardConfig {
   isArray?: boolean;
   title?: string;
 }
+
+export type IGetOptions = (optionType: string) => IOption[];
+
+export interface IInjected {
+  getEndpoint: (endpoint: string) => Promise<any>;
+  getOptions: IGetOptions;
+}
+
+export interface IInputProps {
+  fieldConfig: IFieldConfig;
+  form: any;
+}

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -59,7 +59,7 @@ function inferType (fieldConfig: Partial<IFieldConfig>) {
   if (field.includes('note')) { return 'text'; }
   if (field.includes('body')) { return 'text'; }
   if (field.includes('summary')) { return 'text'; }
-  if (field.includes('percent')) { return 'percent'; }
+  if (field.includes('percent')) { return 'percentage'; }
 
   return 'string';
 }

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -1,4 +1,4 @@
-import { get, isArray } from 'lodash';
+import { get, isArray, sortBy } from 'lodash';
 
 import * as Antd from 'antd';
 
@@ -10,11 +10,14 @@ import {
 import {
   ICardConfig,
   IFieldConfig,
+  IFieldConfigOptionSelect,
   IFieldConfigPartial,
   IFieldSet,
   IFieldSetPartial,
   IFieldSetSimple,
   IFieldSetSimplePartial,
+  IInjected,
+  IOption,
 } from '../interfaces';
 
 import { TYPES } from './types';
@@ -143,4 +146,20 @@ export function getFieldSetFields (fieldSet: IFieldSet): IFieldConfig[] {
   }
 
   return fieldSet.fields;
+}
+
+export function getUnsortedOptions (fieldConfig: IFieldConfigOptionSelect, injected: IInjected): IOption[] {
+  const { options, optionType } = fieldConfig;
+
+  if (options) { return options; }
+  if (fieldConfig.getOptions) { return fieldConfig.getOptions(optionType); }
+  if (injected.getOptions) { return injected.getOptions(optionType); }
+
+  // istanbul ignore next
+  throw new Error ('FieldConfig missing options, getOptions; getOptions not injected');
+}
+
+export function getOptions (fieldConfig: IFieldConfigOptionSelect, injected: IInjected): IOption[] {
+  const unsortedOptions = getUnsortedOptions(fieldConfig, injected);
+  return fieldConfig.sorted ? sortBy(unsortedOptions, 'name') : unsortedOptions;
 }

--- a/test/types/percent.test.js
+++ b/test/types/percent.test.js
@@ -5,19 +5,19 @@ import { Tester } from '@mighty-justice/tester';
 
 import { Card, FormCard } from '../../src';
 
-const field = 'offered_on'
-  , offered_on = '2017-11-22'
-  , expectedDisplay = '11/22/17'
-  , expectedLabel = 'Offered On'
-  , type = 'date'
+const field = 'projected_probability_of_success'
+  , projected_probability_of_success = '0.278'
+  , expectedDisplay = '27.80%'
+  , expectedLabel = 'Projected Probability of Success'
+  , type = 'percent'
   , fieldSets = [[{ field, type }]]
   ;
 
-describe('date', () => {
+describe('percent', () => {
   it('Renders', async () => {
     const props = {
         cardConfig: { fieldSets },
-        model: { offered_on },
+        model: { projected_probability_of_success },
       };
 
     const tester = await new Tester(Card, { props }).mount();

--- a/test/types/percent.test.js
+++ b/test/types/percent.test.js
@@ -1,0 +1,38 @@
+/* global it, describe, expect */
+import React from 'react';
+
+import { Tester } from '@mighty-justice/tester';
+
+import { Card, FormCard } from '../../src';
+
+const field = 'offered_on'
+  , offered_on = '2017-11-22'
+  , expectedDisplay = '11/22/17'
+  , expectedLabel = 'Offered On'
+  , type = 'date'
+  , fieldSets = [[{ field, type }]]
+  ;
+
+describe('date', () => {
+  it('Renders', async () => {
+    const props = {
+        cardConfig: { fieldSets },
+        model: { offered_on },
+      };
+
+    const tester = await new Tester(Card, { props }).mount();
+    expect(tester.text()).toContain(expectedLabel);
+    expect(tester.text()).toContain(expectedDisplay);
+  });
+
+  it('Edits', async () => {
+    const onSave = jest.fn()
+      , props = {
+        cardConfig: { fieldSets },
+        onSave,
+      };
+
+    const tester = await new Tester(FormCard, { props }).mount();
+    expect(tester.text()).toContain(expectedLabel);
+  });
+});

--- a/test/types/radio.test.js
+++ b/test/types/radio.test.js
@@ -1,0 +1,36 @@
+/* global it, describe, expect */
+import React from 'react';
+
+import { Tester } from '@mighty-justice/tester';
+
+import { Card, FormCard } from '../../src';
+
+const field = 'is_open'
+  , optionType = 'yesNo'
+  , expectedLabel = 'Is Open'
+  , type = 'radio'
+  , fieldSets = [[{ field, type, optionType }]]
+  ;
+
+describe('radio', () => {
+  it('Renders', async () => {
+    const props = {
+        cardConfig: { fieldSets },
+        model: { is_open: 'true' },
+      };
+
+    const tester = await new Tester(Card, { props }).mount();
+    expect(tester.text()).toContain(expectedLabel);
+  });
+
+  it('Edits', async () => {
+    const onSave = jest.fn()
+      , props = {
+        cardConfig: { fieldSets },
+        onSave,
+      };
+
+    const tester = await new Tester(FormCard, { props }).mount();
+    expect(tester.text()).toContain(expectedLabel);
+  });
+});


### PR DESCRIPTION
- Move `getOptions` into utils file
- Spend some time reducing duplication in interfaces
- Increase coverage with `radio` and `percent` test stubs