### PR TITLE
Clean up objectSearchCreate tests

### DIFF
--- a/docs/Interfaces.md
+++ b/docs/Interfaces.md
@@ -12,7 +12,7 @@ than to fill all this in (see further below for partials).
 ```ts
 interface IFieldConfig {
   className?: any;
-  disabled?: boolean;
+  disabled: boolean;
   editComponent: any;
   editProps: { [key: string]: any };
   field: string;
@@ -32,7 +32,7 @@ interface IFieldConfig {
   toForm: (data: any, field: string) => any;
   type: string;
   value?: string | number;
-  writeOnly?: boolean;
+  writeOnly: boolean;
 }
 ```
 

--- a/src/building-blocks/NestedFieldSet.tsx
+++ b/src/building-blocks/NestedFieldSet.tsx
@@ -8,11 +8,11 @@ import * as Antd from 'antd';
 
 import {
   FormFieldSet,
-  IFieldSetSimplePartial,
+  IFieldSetPartial,
 } from '../';
 
 interface IProps {
-  fieldSet: IFieldSetSimplePartial;
+  fieldSet: IFieldSetPartial;
   id: string;
   setFields: (data: { [id: string]: { errors: any, value: any } }) => void;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@
 // than to fill all this in (see further below for partials).
 interface IFieldConfigBase {
   className?: any;
-  disabled?: boolean;
+  disabled: boolean;
   editComponent: any;
   editProps: { [key: string]: any };
   field: string;
@@ -26,7 +26,7 @@ interface IFieldConfigBase {
   toForm: (data: any, field: string) => any;
   type: string;
   value?: string | number;
-  writeOnly?: boolean;
+  writeOnly: boolean;
 }
 
 export interface IAntFormField {

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -89,6 +89,8 @@ export function fillInFieldConfig (fieldConfig: IFieldConfigPartial): IFieldConf
     } : undefined;
 
   return {
+    // Universal defaults
+    disabled: false,
     key: fieldConfig.field,
     label,
     readOnly: false,
@@ -96,16 +98,20 @@ export function fillInFieldConfig (fieldConfig: IFieldConfigPartial): IFieldConf
     required: false,
     showLabel: true,
     type,
+    writeOnly: false,
 
+    // Overrides prioritized
     ...typeDefaults,
     ...TYPES[type],
     ...fieldConfig,
 
+    // Merge nested object
     editProps: {
       ...fieldConfig.editProps,
       ...TYPES[type].editProps,
     },
 
+    // Merge nested object
     formValidationRules: {
       ...fieldConfig.formValidationRules,
       ...TYPES[type].formValidationRules,

--- a/test/types/objectSearchCreate.test.js
+++ b/test/types/objectSearchCreate.test.js
@@ -83,7 +83,7 @@ describe('objectSearchCreate', () => {
       , tester = await getTester(props) ;
 
     await searchFor(tester, field, result, searchTerm);
-    selectAddNew(tester);
+    await selectAddNew(tester);
 
     expect(tester.text()).toContain('Name');
     expect(tester.text()).toContain('Amount Owed');
@@ -93,7 +93,6 @@ describe('objectSearchCreate', () => {
     tester.find('form').simulate('submit');
     expect(tester.text()).toContain('required');
     expect(onSave).not.toHaveBeenCalled();
-    selectAddNew(tester);
 
     changeInput(tester.find('input#name'), searchTerm);
     tester.find('form').simulate('submit');


### PR DESCRIPTION
Other very small fixes:
- `IFieldSetPartial` is a super-type of `IFieldSetSimplePartial`, so this is an easy change
- `disabled` and `writeOnly` are filled in, therefore guaranteed in final `fieldConfig`