### PR TITLE
optionType is optional in OptionSelect

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,7 +46,7 @@ export interface IOption {
 export interface IFieldConfigOptionSelect extends IFieldConfigBase {
   getOptions?: (optionType: string) => IOption[];
   options?: IOption[];
-  optionType: string;
+  optionType?: string;
   showSearch?: boolean;
   sorted?: boolean;
 }


### PR DESCRIPTION
optionSelect type FieldConfigs can include an `options` attribute instead, which explicitly defines the options.