### PR TITLE
Allow FormDrawer width to be a string

### DIFF
--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -22,7 +22,7 @@ interface IProps {
   onSave: (args: any) => Promise<void>;
   onSuccess?: (args?: any) => void;
   title: string;
-  width?: number;
+  width?: number | string;
 }
 
 @autoBindMethods


### PR DESCRIPTION
Ant Design default it to 256px, so I MUST set it. 🤦‍♂️ 
My fix is allowing a string so that I can set it to 100% and use max-width to control it in CSS.

It works, I tested it locally.