### PR TITLE
Rename ArrayCard.extra to renderTopRight

### DIFF
--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { get } from 'lodash';
 
-import Info, { Label, Value } from './Info';
+import { fillInFieldConfig, filterInsertIf } from '../utilities/common';
 import { IFieldConfig } from '../interfaces';
 
-import { fillInFieldConfig, filterInsertIf } from '../utilities/common';
+import Info, { Label, Value } from './Info';
 
 interface IProps {
   fieldConfig: IFieldConfig;

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -4,9 +4,15 @@ import { observer } from 'mobx-react';
 
 import * as Antd from 'antd';
 
-import { IFieldSetPartial } from '../interfaces';
-import { fillInFieldSet, filterInsertIf, getFieldSetFields, isFieldSetSimple } from '../utilities/common';
+import {
+  fillInFieldSet,
+  filterInsertIf,
+  getFieldSetFields,
+  isFieldSetSimple,
+} from '../utilities/common';
+
 import CardField from '../building-blocks/CardField';
+import { IFieldSetPartial } from '../interfaces';
 
 interface IProps {
   fieldSet: IFieldSetPartial;

--- a/src/components/ArrayCard.tsx
+++ b/src/components/ArrayCard.tsx
@@ -9,19 +9,19 @@ import { ICommonCardProps } from '../interfaces';
 
 interface IProps extends ICommonCardProps {
   children?: any;
-  extra?: any;
   isLoading?: boolean;
   model: any;
+  renderTopRight?: any;
 }
 
 @observer
 class ArrayCard extends Component<IProps> {
   public render () {
-    const { title, extra, isLoading, model, fieldSets, classNameSuffix } = this.props;
+    const { title, renderTopRight, isLoading, model, fieldSets, classNameSuffix } = this.props;
     if (isEmpty(model)) { return null; }
 
     return (
-      <Antd.Card title={title} extra={extra} loading={isLoading}>
+      <Antd.Card title={title} extra={renderTopRight && renderTopRight()} loading={isLoading}>
         {model.map((modelItem: any) => (
           <Card
             classNameSuffix={classNameSuffix}

--- a/src/components/ArrayCard.tsx
+++ b/src/components/ArrayCard.tsx
@@ -11,7 +11,7 @@ interface IProps extends ICommonCardProps {
   children?: any;
   isLoading?: boolean;
   model: any;
-  renderTopRight?: any;
+  renderTopRight?: () => any;
 }
 
 @observer

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -6,10 +6,11 @@ import SmartBool from '@mighty-justice/smart-bool';
 import { kebabCase } from 'lodash';
 
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
-import Card from './Card';
-import FormCard from './FormCard';
 import GuardedButton from '../building-blocks/GuardedButton';
 import { ICommonCardProps } from '../interfaces';
+
+import Card from './Card';
+import FormCard from './FormCard';
 
 interface IProps extends ICommonCardProps {
   children?: any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,5 +26,5 @@ export { default as Rate, formatRating } from './inputs/Rate';
 
 // Utility classes and functions
 export { default as FormManager } from './utilities/FormManager';
-export * from './utilities/common';
 export * from './interfaces';
+export * from './utilities/common';


### PR DESCRIPTION
- This brings `ArrayCard` in line with `Card`, `SummaryCard`, and `FormCard`.
- Also includes some small sorting improvements