### PR TITLE
Add standard propDefaults for form components

### DIFF
--- a/src/components/EditableArrayCard.tsx
+++ b/src/components/EditableArrayCard.tsx
@@ -8,7 +8,7 @@ import SmartBool from '@mighty-justice/smart-bool';
 import * as Antd from 'antd';
 
 import GuardedButton from '../building-blocks/GuardedButton';
-import { asyncNoop } from '../utilities/common';
+import { formPropsDefaults } from '../propsDefaults';
 import { IFormProps } from '../props';
 
 import EditableCard from './EditableCard';
@@ -27,7 +27,7 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
   @observable private isAddingNew = new SmartBool();
 
   public static defaultProps: Partial<IEditableArrayCardProps> = {
-    onSuccess: asyncNoop,
+    ...formPropsDefaults,
   };
 
   private async handleSaveNew (model: any) {

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -8,7 +8,7 @@ import SmartBool from '@mighty-justice/smart-bool';
 
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
 import GuardedButton from '../building-blocks/GuardedButton';
-import { asyncNoop } from '../utilities/common';
+import { formPropsDefaults } from '../propsDefaults';
 import { IFormProps } from '../props';
 
 import Card, { ICardProps } from './Card';
@@ -18,10 +18,6 @@ export interface IEditableCardProps extends ICardProps, IFormProps {
   onDelete?: (model: unknown) => Promise<any>;
 }
 
-interface IPropDefaults extends IEditableCardProps {
-  onSuccess: () => Promise<any>;
-}
-
 @autoBindMethods
 @observer
 class EditableCard extends Component<IEditableCardProps> {
@@ -29,16 +25,11 @@ class EditableCard extends Component<IEditableCardProps> {
   @observable private isEditing = new SmartBool();
 
   public static defaultProps: Partial<IEditableCardProps> = {
-    onSave: asyncNoop,
-    onSuccess: asyncNoop,
+    ...formPropsDefaults,
   };
 
-  public get propsWithDefaults () {
-    return this.props as IPropDefaults;
-  }
-
   private async handleDelete () {
-    const { model, onDelete, onSuccess } = this.propsWithDefaults;
+    const { model, onDelete, onSuccess } = this.props;
     // istanbul ignore next
     if (!onDelete) { return; }
 
@@ -49,15 +40,15 @@ class EditableCard extends Component<IEditableCardProps> {
   }
 
   private async handleSave (model: any) {
-    const { onSuccess, onSave } = this.propsWithDefaults;
+    const { onSuccess, onSave } = this.props;
 
     await onSave(model);
     await onSuccess();
   }
 
   private get deleteButton () {
-    const { isGuarded, title, onDelete, isLoading } = this.propsWithDefaults
-      , classNameSuffix = this.propsWithDefaults.classNameSuffix || kebabCase(title);
+    const { isGuarded, title, onDelete, isLoading } = this.props
+      , classNameSuffix = this.props.classNameSuffix || kebabCase(title);
 
     if (!onDelete) { return; }
 
@@ -78,8 +69,8 @@ class EditableCard extends Component<IEditableCardProps> {
   }
 
   private get editButton () {
-    const { isLoading, title, isGuarded } = this.propsWithDefaults
-      , classNameSuffix = this.propsWithDefaults.classNameSuffix || kebabCase(title);
+    const { isLoading, title, isGuarded } = this.props
+      , classNameSuffix = this.props.classNameSuffix || kebabCase(title);
 
     return (
       <GuardedButton

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -3,13 +3,13 @@ import React, { Component, Fragment } from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
-import { noop } from 'lodash';
 
 import * as Antd from 'antd';
 
 import FormFieldSet from '../building-blocks/FormFieldSet';
 import FormManager from '../utilities/FormManager';
-import { asyncNoop, fillInFieldSets } from '../utilities/common';
+import { fillInFieldSets } from '../utilities/common';
+import { formPropsDefaults } from '../propsDefaults';
 import { IFieldSet } from '../interfaces';
 import { IFormProps, IWrappedFormProps } from '../props';
 
@@ -25,8 +25,7 @@ export class UnwrappedFormCard extends Component<IFormCardWrappedProps> {
   private formManager: FormManager;
 
   public static defaultProps: Partial<IFormCardWrappedProps> = {
-    onCancel: noop,
-    onSuccess: asyncNoop,
+    ...formPropsDefaults,
   };
 
   public constructor (props: IFormCardWrappedProps) {
@@ -103,8 +102,7 @@ const WrappedFormCard = Antd.Form.create()(UnwrappedFormCard);
 @observer
 export class FormCard extends Component<IFormCardProps> {
   public static defaultProps: Partial<IFormCardWrappedProps> = {
-    onCancel: noop,
-    onSuccess: asyncNoop,
+    ...formPropsDefaults,
   };
 
   public render () {

--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -13,6 +13,7 @@ import {
   FormManager,
 } from '../';
 
+import { formPropsDefaults } from '../propsDefaults';
 import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
 
 export interface IFormDrawerProps extends ISharedComponentProps, IWrappedFormProps, IFormProps {
@@ -24,6 +25,10 @@ export interface IFormDrawerProps extends ISharedComponentProps, IWrappedFormPro
 @observer
 class BaseFormDrawer extends Component<IFormDrawerProps> {
   private formManager: FormManager;
+
+  public static defaultProps: Partial<IFormDrawerProps> = {
+    ...formPropsDefaults,
+  };
 
   @computed
   private get fieldSets () {

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -8,6 +8,7 @@ import * as Antd from 'antd';
 import FormFieldSet from '../building-blocks/FormFieldSet';
 import FormManager from '../utilities/FormManager';
 import { fillInFieldSets } from '../utilities/common';
+import { formPropsDefaults } from '../propsDefaults';
 import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
 
 export interface IFormModalProps extends ISharedComponentProps, IWrappedFormProps, IFormProps {
@@ -24,7 +25,7 @@ class FormModal extends Component<IFormModalProps> {
   private formManager: FormManager;
 
   public static defaultProps: Partial<IFormModalProps> = {
-    saveText: 'Save',
+    ...formPropsDefaults,
   };
 
   public get propsWithDefaults () {

--- a/src/props.ts
+++ b/src/props.ts
@@ -54,8 +54,8 @@ export interface IWrappedFormProps {
 export interface IFormProps {
   defaults?: object;
   isGuarded?: boolean;
-  onCancel?: () => void;
+  onCancel: () => void;
   onSave: (data: object) => Promise<void>;
   onSuccess: () => Promise<any>;
-  saveText?: string;
+  saveText: string;
 }

--- a/src/propsDefaults.ts
+++ b/src/propsDefaults.ts
@@ -1,0 +1,9 @@
+import { noop } from 'lodash';
+import { asyncNoop } from './utilities/common';
+
+export const formPropsDefaults = {
+  onCancel: noop,
+  onSave: asyncNoop,
+  onSuccess: asyncNoop,
+  saveText: 'Save',
+};


### PR DESCRIPTION
Note that `propDefaults` make non-optional interface attributes optional for the caller.

So `onSubmit: blabla` + `onSubmit: asyncNoop` === `onSubmit?: blabla`