### PR TITLE
Standardize and simplify forms with Form component

### DIFF
--- a/.storybook/config.tsx
+++ b/.storybook/config.tsx
@@ -8,33 +8,52 @@ import { withInfo } from '@storybook/addon-info';
 import 'antd/dist/antd.css';
 import './stories.css';
 
-const PropsTable = (props: any) => (
-  <Table
-    bordered
-    columns={[
-      {
-        dataIndex: 'property',
-        sorter: (a: any, b: any) => (a.property).localeCompare(b.property),
-        title: 'Prop',
-      },
-      {
-        dataIndex: 'propType.name',
-        sorter: (a: any, b: any) => (a.propType.name).localeCompare(b.propType.name),
-        title: 'Type',
-      },
-      {
-        dataIndex: 'required',
-        defaultSortOrder: 'descend' as 'descend',
-        render: (value: any) => value ? <Tag color='red'>Yes</Tag> : <Tag>No</Tag>,
-        sorter: (a: any, b: any) => (a.required === b.required) ? 0 : a.required ? 1 : -1,
-        title: 'required',
-      },
-    ].map(row => ({ ...row, key: row.dataIndex }))}
-    dataSource={props.propDefinitions}
-    pagination={false}
-    rowKey='property'
-  />
-);
+function stringSortFor (attr: string) {
+  return (a: any, b: any) => (a[attr]).localeCompare(b[attr]);
+}
+
+function boolSortFor (attr: string) {
+  return (a: any, b: any) => (a[attr] === b[attr]) ? 0 : a[attr] ? 1 : -1;
+}
+
+const PropsTable = (props: any) => {
+  const dataSource = props.propDefinitions.map((propDefinition: any) => ({
+    ...propDefinition,
+    required: propDefinition.required && !propDefinition.defaultValue,
+  }));
+
+  return (
+    <Table
+      bordered
+      columns={[
+        {
+          dataIndex: 'property',
+          sorter: stringSortFor('property'),
+          title: 'Prop',
+        },
+        {
+          dataIndex: 'propType.name',
+          sorter: stringSortFor('name'),
+          title: 'Type',
+        },
+        {
+          dataIndex: 'required',
+          defaultSortOrder: 'descend' as 'descend',
+          render: (value: any) => value ? <Tag color='red'>Yes</Tag> : <Tag>No</Tag>,
+          sorter: boolSortFor('required'),
+          title: 'required',
+        },
+        {
+          dataIndex: 'defaultValue',
+          title: 'defaultValue',
+        },
+      ].map(row => ({ ...row, key: row.dataIndex }))}
+      dataSource={dataSource}
+      pagination={false}
+      rowKey='property'
+    />
+  );
+}
 
 const providers = {
   getEndpoint: async (_endpoint: string) => ({ results: [

--- a/.storybook/config.tsx
+++ b/.storybook/config.tsx
@@ -16,6 +16,30 @@ function boolSortFor (attr: string) {
   return (a: any, b: any) => (a[attr] === b[attr]) ? 0 : a[attr] ? 1 : -1;
 }
 
+const propTableColumns = [
+  {
+    dataIndex: 'property',
+    sorter: stringSortFor('property'),
+    title: 'Prop',
+  },
+  {
+    dataIndex: 'propType.name',
+    sorter: stringSortFor('name'),
+    title: 'Type',
+  },
+  {
+    dataIndex: 'required',
+    defaultSortOrder: 'descend' as 'descend',
+    render: (value: any) => value ? <Tag color='red'>Yes</Tag> : <Tag>No</Tag>,
+    sorter: boolSortFor('required'),
+    title: 'required',
+  },
+  {
+    dataIndex: 'defaultValue',
+    title: 'default',
+  },
+].map(row => ({ ...row, key: row.dataIndex }));
+
 const PropsTable = (props: any) => {
   const dataSource = props.propDefinitions.map((propDefinition: any) => ({
     ...propDefinition,
@@ -25,35 +49,13 @@ const PropsTable = (props: any) => {
   return (
     <Table
       bordered
-      columns={[
-        {
-          dataIndex: 'property',
-          sorter: stringSortFor('property'),
-          title: 'Prop',
-        },
-        {
-          dataIndex: 'propType.name',
-          sorter: stringSortFor('name'),
-          title: 'Type',
-        },
-        {
-          dataIndex: 'required',
-          defaultSortOrder: 'descend' as 'descend',
-          render: (value: any) => value ? <Tag color='red'>Yes</Tag> : <Tag>No</Tag>,
-          sorter: boolSortFor('required'),
-          title: 'required',
-        },
-        {
-          dataIndex: 'defaultValue',
-          title: 'defaultValue',
-        },
-      ].map(row => ({ ...row, key: row.dataIndex }))}
+      columns={propTableColumns}
       dataSource={dataSource}
       pagination={false}
       rowKey='property'
     />
   );
-}
+};
 
 const providers = {
   getEndpoint: async (_endpoint: string) => ({ results: [

--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -18,6 +18,11 @@
   box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.5);
 }
 
+#story-root > .ant-form {
+  background-color: white;
+  padding: 15px;
+}
+
 .button-toolbar button {
   margin-right: 10px;
 }
@@ -29,4 +34,8 @@
 .markdown-body {
   background-color: white;
   margin: 30px 0;
+}
+
+.align-right {
+  text-align: right;
 }

--- a/src/components/EditableArrayCard.tsx
+++ b/src/components/EditableArrayCard.tsx
@@ -9,13 +9,13 @@ import * as Antd from 'antd';
 
 import GuardedButton from '../building-blocks/GuardedButton';
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps } from '../props';
+import { ISharedFormProps } from '../props';
 
 import EditableCard from './EditableCard';
 import FormCard from './FormCard';
 import { IArrayCardProps } from './ArrayCard';
 
-export interface IEditableArrayCardProps extends IArrayCardProps, IFormProps {
+export interface IEditableArrayCardProps extends IArrayCardProps, ISharedFormProps {
   defaults?: object;
   onCreate: (model: unknown) => Promise<any>;
   onDelete?: (model: unknown) => Promise<any>;

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -9,12 +9,12 @@ import SmartBool from '@mighty-justice/smart-bool';
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
 import GuardedButton from '../building-blocks/GuardedButton';
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps } from '../props';
+import { ISharedFormProps } from '../props';
 
 import Card, { ICardProps } from './Card';
 import FormCard from './FormCard';
 
-export interface IEditableCardProps extends ICardProps, IFormProps {
+export interface IEditableCardProps extends ICardProps, ISharedFormProps {
   onDelete?: (model: unknown) => Promise<any>;
 }
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,0 +1,119 @@
+// tslint:disable max-classes-per-file
+import React, { Component, Fragment } from 'react';
+import { computed } from 'mobx';
+import { observer } from 'mobx-react';
+import autoBindMethods from 'class-autobind-decorator';
+
+import * as Antd from 'antd';
+
+import FormFieldSet from '../building-blocks/FormFieldSet';
+import FormManager from '../utilities/FormManager';
+import { fillInFieldSets } from '../utilities/common';
+import { formPropsDefaults } from '../propsDefaults';
+import { IFieldSet } from '../interfaces';
+
+import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
+import { ButtonToolbar } from '../index';
+
+export interface IFormComponentProps extends ISharedComponentProps, IFormProps {
+  setRefFormManager?: (formManager: FormManager) => void;
+}
+
+export interface IFormWrappedProps extends IFormComponentProps, IWrappedFormProps {}
+
+@autoBindMethods
+@observer
+export class UnwrappedForm extends Component<IFormWrappedProps> {
+  private formManager: FormManager;
+
+  public static defaultProps: Partial<IFormWrappedProps> = {
+    ...formPropsDefaults,
+  };
+
+  public constructor (props: IFormWrappedProps) {
+    super(props);
+    const { model, onSave, onCancel, form, setRefFormManager } = props as IFormWrappedProps;
+
+    this.formManager = new FormManager(
+      form,
+      this.fieldSets,
+      {
+        model,
+        onSave,
+        onSuccess: onCancel,
+      },
+    );
+
+    if (setRefFormManager) {
+      setRefFormManager(this.formManager);
+    }
+  }
+
+  @computed
+  private get fieldSets () {
+    return fillInFieldSets(this.props.fieldSets);
+  }
+
+  public render () {
+    const { onCancel, defaults, model, form, saveText } = this.props;
+
+    return (
+      <Antd.Form layout='vertical' onSubmit={this.formManager.onSave} className='mfa-form'>
+        {this.fieldSets.map((fieldSet: IFieldSet, idx: number) => (
+          <Fragment key={idx}>
+            {(idx > 0) && <Antd.Divider key={`divider-${idx}`} />}
+            <div>
+              <FormFieldSet
+                defaults={defaults}
+                fieldSet={fieldSet}
+                form={form}
+                formManager={this.formManager}
+                model={model}
+              />
+            </div>
+          </Fragment>
+        ))}
+
+        {this.props.children}
+
+        <Antd.Divider />
+
+        <ButtonToolbar align='right'>
+          <Antd.Button
+            disabled={this.formManager.saving}
+            onClick={onCancel}
+            size='large'
+          >
+            Cancel
+          </Antd.Button>
+
+          <Antd.Button
+            htmlType='submit'
+            loading={this.formManager.saving}
+            size='large'
+            type='primary'
+          >
+            {saveText}
+          </Antd.Button>
+        </ButtonToolbar>
+      </Antd.Form>
+    );
+  }
+}
+
+// istanbul ignore next
+const WrappedForm = Antd.Form.create()(UnwrappedForm);
+
+@autoBindMethods
+@observer
+export class Form extends Component<IFormComponentProps> {
+  public static defaultProps: Partial<IFormWrappedProps> = {
+    ...formPropsDefaults,
+  };
+
+  public render () {
+    return <WrappedForm {...this.props} />;
+  }
+}
+
+export default Form;

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -6,33 +6,35 @@ import autoBindMethods from 'class-autobind-decorator';
 
 import * as Antd from 'antd';
 
+import ButtonToolbar from '../building-blocks/ButtonToolbar';
 import FormFieldSet from '../building-blocks/FormFieldSet';
 import FormManager from '../utilities/FormManager';
 import { fillInFieldSets } from '../utilities/common';
 import { formPropsDefaults } from '../propsDefaults';
 import { IFieldSet } from '../interfaces';
+import { ISharedFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
 
-import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
-import { ButtonToolbar } from '../index';
-
-export interface IFormComponentProps extends ISharedComponentProps, IFormProps {
+export interface IFormProps extends ISharedComponentProps, ISharedFormProps {
   setRefFormManager?: (formManager: FormManager) => void;
+  showControls: boolean;
 }
 
-export interface IFormWrappedProps extends IFormComponentProps, IWrappedFormProps {}
+export interface IFormWrappedProps extends IFormProps, IWrappedFormProps {}
 
 @autoBindMethods
 @observer
 export class UnwrappedForm extends Component<IFormWrappedProps> {
   private formManager: FormManager;
 
-  public static defaultProps: Partial<IFormWrappedProps> = {
-    ...formPropsDefaults,
-  };
-
   public constructor (props: IFormWrappedProps) {
     super(props);
-    const { model, onSave, onCancel, form, setRefFormManager } = props as IFormWrappedProps;
+    const {
+      form,
+      model,
+      onCancel,
+      onSave,
+      setRefFormManager,
+    } = props;
 
     this.formManager = new FormManager(
       form,
@@ -54,28 +56,14 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
-  public render () {
-    const { onCancel, defaults, model, form, saveText } = this.props;
+  private renderControls () {
+    const {
+      onCancel,
+      saveText,
+    } = this.props;
 
     return (
-      <Antd.Form layout='vertical' onSubmit={this.formManager.onSave} className='mfa-form'>
-        {this.fieldSets.map((fieldSet: IFieldSet, idx: number) => (
-          <Fragment key={idx}>
-            {(idx > 0) && <Antd.Divider key={`divider-${idx}`} />}
-            <div>
-              <FormFieldSet
-                defaults={defaults}
-                fieldSet={fieldSet}
-                form={form}
-                formManager={this.formManager}
-                model={model}
-              />
-            </div>
-          </Fragment>
-        ))}
-
-        {this.props.children}
-
+      <>
         <Antd.Divider />
 
         <ButtonToolbar align='right'>
@@ -96,6 +84,42 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
             {saveText}
           </Antd.Button>
         </ButtonToolbar>
+      </>
+    );
+  }
+
+  public render () {
+    const {
+      defaults,
+      form,
+      model,
+      showControls,
+      title,
+    } = this.props;
+
+    return (
+      <Antd.Form layout='vertical' onSubmit={this.formManager.onSave} className='mfa-form'>
+        {title && <h2>{title}</h2>}
+
+        {this.fieldSets.map((fieldSet: IFieldSet, idx: number) => (
+          <Fragment key={idx}>
+            {(idx > 0) && <Antd.Divider key={`divider-${idx}`} />}
+
+            <div>
+              <FormFieldSet
+                defaults={defaults}
+                fieldSet={fieldSet}
+                form={form}
+                formManager={this.formManager}
+                model={model}
+              />
+            </div>
+          </Fragment>
+        ))}
+
+        {this.props.children}
+
+        {showControls && this.renderControls()}
       </Antd.Form>
     );
   }
@@ -106,9 +130,10 @@ const WrappedForm = Antd.Form.create()(UnwrappedForm);
 
 @autoBindMethods
 @observer
-export class Form extends Component<IFormComponentProps> {
+export class Form extends Component<IFormProps> {
   public static defaultProps: Partial<IFormWrappedProps> = {
     ...formPropsDefaults,
+    showControls: true,
   };
 
   public render () {

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -1,112 +1,33 @@
-// tslint:disable max-classes-per-file
-import React, { Component, Fragment } from 'react';
-import { computed } from 'mobx';
+import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import { omit } from 'lodash';
 
 import * as Antd from 'antd';
 
-import FormFieldSet from '../building-blocks/FormFieldSet';
-import FormManager from '../utilities/FormManager';
-import { fillInFieldSets } from '../utilities/common';
 import { formPropsDefaults } from '../propsDefaults';
-import { IFieldSet } from '../interfaces';
-import { IFormProps, IWrappedFormProps } from '../props';
+import { IFormProps } from '../props';
 
 import { ICardProps } from './Card';
+import Form from './Form';
 
 export interface IFormCardProps extends IFormProps, ICardProps {}
-
-export interface IFormCardWrappedProps extends IFormCardProps, IWrappedFormProps {}
-
-@autoBindMethods
-@observer
-export class UnwrappedFormCard extends Component<IFormCardWrappedProps> {
-  private formManager: FormManager;
-
-  public static defaultProps: Partial<IFormCardWrappedProps> = {
-    ...formPropsDefaults,
-  };
-
-  public constructor (props: IFormCardWrappedProps) {
-    super(props);
-    const { model, onSave, onCancel, form } = props as IFormCardWrappedProps;
-
-    this.formManager = new FormManager(
-      form,
-      this.fieldSets,
-      {
-        model,
-        onSave,
-        onSuccess: onCancel,
-      },
-    );
-  }
-
-  @computed
-  private get fieldSets () {
-    return fillInFieldSets(this.props.fieldSets);
-  }
-
-  public render () {
-    const { isLoading, title, onCancel, defaults, model, form, renderTopRight } = this.props;
-
-    return (
-      <Antd.Card loading={isLoading} title={title} extra={renderTopRight && renderTopRight()}>
-        <Antd.Form onSubmit={this.formManager.onSave} className='notes-form'>
-          {this.fieldSets.map((fieldSet: IFieldSet, idx: number) => (
-            <Fragment key={idx}>
-              {(idx > 0) && <Antd.Divider key={`divider-${idx}`} />}
-              <div>
-                <FormFieldSet
-                  defaults={defaults}
-                  fieldSet={fieldSet}
-                  form={form}
-                  formManager={this.formManager}
-                  model={model}
-                />
-              </div>
-            </Fragment>
-          ))}
-
-          {this.props.children}
-
-          <div className='button-toolbar'>
-            <Antd.Button
-              htmlType='submit'
-              loading={this.formManager.saving}
-              size='large'
-              type='primary'
-            >
-              Save
-            </Antd.Button>
-
-            <Antd.Button
-              disabled={this.formManager.saving}
-              onClick={onCancel}
-              size='large'
-            >
-              Cancel
-            </Antd.Button>
-          </div>
-        </Antd.Form>
-      </Antd.Card>
-    );
-  }
-}
-
-// istanbul ignore next
-const WrappedFormCard = Antd.Form.create()(UnwrappedFormCard);
 
 @autoBindMethods
 @observer
 export class FormCard extends Component<IFormCardProps> {
-  public static defaultProps: Partial<IFormCardWrappedProps> = {
+  public static defaultProps: Partial<IFormCardProps> = {
     ...formPropsDefaults,
   };
 
   public render () {
-    return <WrappedFormCard {...this.props} />;
+    const { isLoading, title, renderTopRight } = this.props;
+
+    return (
+      <Antd.Card loading={isLoading} title={title} extra={renderTopRight && renderTopRight()}>
+        <Form {...omit(this.props, ['renderTopRight'])} />
+      </Antd.Card>
+    );
   }
 }
 

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -6,12 +6,12 @@ import { omit } from 'lodash';
 import * as Antd from 'antd';
 
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps } from '../props';
+import { ISharedFormProps } from '../props';
 
 import { ICardProps } from './Card';
 import Form from './Form';
 
-export interface IFormCardProps extends IFormProps, ICardProps {}
+export interface IFormCardProps extends ISharedFormProps, ICardProps {}
 
 @autoBindMethods
 @observer
@@ -21,11 +21,12 @@ export class FormCard extends Component<IFormCardProps> {
   };
 
   public render () {
-    const { isLoading, title, renderTopRight } = this.props;
+    const { isLoading, title, renderTopRight } = this.props
+      , HANDLED_PROPS = ['title', 'renderTopRight'];
 
     return (
       <Antd.Card loading={isLoading} title={title} extra={renderTopRight && renderTopRight()}>
-        <Form {...omit(this.props, ['renderTopRight'])} />
+        <Form {...omit(this.props, HANDLED_PROPS)} />
       </Antd.Card>
     );
   }

--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import { omit } from 'lodash';
+
 import SmartBool from '@mighty-justice/smart-bool';
 
 import * as Antd from 'antd';
 
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps, ISharedComponentProps } from '../props';
+import { ISharedFormProps, ISharedComponentProps } from '../props';
 
 import Form from './Form';
 
-export interface IFormDrawerProps extends ISharedComponentProps, IFormProps {
+export interface IFormDrawerProps extends ISharedComponentProps, ISharedFormProps {
   isVisible: SmartBool;
   width?: number | string;
 }
@@ -23,7 +25,8 @@ class FormDrawer extends Component<IFormDrawerProps> {
   };
 
   public render () {
-    const { isVisible, title, width } = this.props;
+    const { isVisible, title, width } = this.props
+      , HANDLED_PROPS = ['title', 'isVisible'];
 
     return (
       <Antd.Drawer
@@ -37,7 +40,10 @@ class FormDrawer extends Component<IFormDrawerProps> {
         visible={isVisible.isTrue}
         width={width}
       >
-        <Form {...this.props} />
+        <Form
+          onCancel={isVisible.setFalse}
+          {...omit(this.props, HANDLED_PROPS)}
+        />
       </Antd.Drawer>
     );
   }

--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -41,8 +41,8 @@ class FormDrawer extends Component<IFormDrawerProps> {
         width={width}
       >
         <Form
-          onCancel={isVisible.setFalse}
           {...omit(this.props, HANDLED_PROPS)}
+          onCancel={isVisible.setFalse}
         />
       </Antd.Drawer>
     );

--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -1,67 +1,29 @@
-// tslint:disable max-classes-per-file
 import React, { Component } from 'react';
-import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import SmartBool from '@mighty-justice/smart-bool';
 
 import * as Antd from 'antd';
 
-import {
-  ButtonToolbar,
-  fillInFieldSets,
-  FormFieldSet,
-  FormManager,
-} from '../';
-
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
+import { IFormProps, ISharedComponentProps } from '../props';
+
+import Form from './Form';
 
 export interface IFormDrawerProps extends ISharedComponentProps, IFormProps {
   isVisible: SmartBool;
   width?: number | string;
 }
 
-export interface IFormDrawerWrappedProps extends IFormDrawerProps, IWrappedFormProps {}
-
 @autoBindMethods
 @observer
-class UnwrappedFormDrawer extends Component<IFormDrawerWrappedProps> {
-  private formManager: FormManager;
-
-  public static defaultProps: Partial<IFormDrawerWrappedProps> = {
+class FormDrawer extends Component<IFormDrawerProps> {
+  public static defaultProps: Partial<IFormDrawerProps> = {
     ...formPropsDefaults,
   };
 
-  @computed
-  private get fieldSets () {
-    return fillInFieldSets(this.props.fieldSets);
-  }
-
-  public constructor (props: IFormDrawerWrappedProps) {
-    super(props);
-
-    const {
-      form,
-      isVisible,
-      model,
-      onSave,
-      onSuccess,
-    } = props;
-
-    this.formManager = new FormManager(
-      form,
-      this.fieldSets,
-      {
-        model,
-        onSave,
-        onSuccess: onSuccess || isVisible.setFalse,
-      },
-    );
-  }
-
   public render () {
-    const { form, isVisible, model, title, width, defaults } = this.props;
+    const { isVisible, title, width } = this.props;
 
     return (
       <Antd.Drawer
@@ -75,54 +37,9 @@ class UnwrappedFormDrawer extends Component<IFormDrawerWrappedProps> {
         visible={isVisible.isTrue}
         width={width}
       >
-        <Antd.Form layout='vertical' onSubmit={this.formManager.onSave}>
-          {this.fieldSets.map((fieldSet, idx) => (
-            <div key={idx}>
-              <FormFieldSet
-                defaults={defaults}
-                fieldSet={fieldSet}
-                form={form}
-                formManager={this.formManager}
-                model={model}
-              />
-            </div>
-          ))}
-          <Antd.Divider />
-
-          <ButtonToolbar align='right'>
-            <Antd.Button
-              disabled={this.formManager.saving}
-              onClick={isVisible.setFalse}
-              size='large'
-            >
-              Cancel
-            </Antd.Button>
-            <Antd.Button
-              htmlType='submit'
-              loading={this.formManager.saving}
-              size='large'
-              type='primary'
-            >
-              Submit
-            </Antd.Button>
-          </ButtonToolbar>
-        </Antd.Form>
+        <Form {...this.props} />
       </Antd.Drawer>
     );
-  }
-}
-
-const WrappedFormDrawer = Antd.Form.create()(UnwrappedFormDrawer);
-
-@autoBindMethods
-@observer
-export class FormDrawer extends Component<IFormDrawerProps> {
-  public static defaultProps: Partial<IFormDrawerProps> = {
-    ...formPropsDefaults,
-  };
-
-  public render () {
-    return <WrappedFormDrawer {...this.props} />;
   }
 }
 

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -61,9 +61,9 @@ class FormModal extends Component<IFormModalProps> {
         {this.props.childrenBefore}
 
         <Form
+          {...omit(this.props, HANDLED_PROPS)}
           setRefFormManager={this.setRefFormManager}
           showControls={false}
-          {...omit(this.props, HANDLED_PROPS)}
         />
 
         {this.props.children}

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -1,98 +1,66 @@
-// tslint:disable max-classes-per-file
 import React, { Component } from 'react';
-import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 
 import * as Antd from 'antd';
 
-import FormFieldSet from '../building-blocks/FormFieldSet';
 import FormManager from '../utilities/FormManager';
-import { fillInFieldSets } from '../utilities/common';
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps, ISharedComponentProps, IWrappedFormProps } from '../props';
+import { IFormProps, ISharedComponentProps } from '../props';
+
+import Form from './Form';
 
 export interface IFormModalProps extends ISharedComponentProps, IFormProps {
   childrenBefore?: React.ReactNode;
 }
 
-export interface IFormModalWrappedProps extends IFormModalProps, IWrappedFormProps {}
-
 @autoBindMethods
 @observer
-class UnwrappedFormModal extends Component<IFormModalWrappedProps> {
-  private formManager: FormManager;
+class FormModal extends Component<IFormModalProps> {
+  private formManager?: FormManager;
 
-  public static defaultProps: Partial<IFormModalWrappedProps> = {
-    ...formPropsDefaults,
-  };
-
-  public constructor (props: IFormModalWrappedProps) {
-    super(props);
-    const { model, onSave, onCancel } = props;
-
-    this.formManager = new FormManager(
-      props.form,
-      this.fieldSets,
-      {
-        model,
-        onSave,
-        onSuccess: onCancel,
-      },
-    );
-  }
-
-  @computed
-  private get fieldSets () {
-    return fillInFieldSets(this.props.fieldSets);
-  }
-
-  public render () {
-    const { title, onCancel, defaults, model, form } = this.props
-      , { saveText } = this.props;
-
-    return (
-      <Antd.Modal
-        confirmLoading={this.formManager.saving}
-        okText={this.formManager.saving ? 'Saving...' : saveText}
-        onCancel={onCancel}
-        onOk={this.formManager.onSave}
-        title={title}
-        visible
-      >
-        <Antd.Form onSubmit={this.formManager.onSave} className='notes-form'>
-          {this.props.childrenBefore}
-
-          {this.fieldSets.map((fieldSet, idx) => (
-            <div key={idx}>
-              <FormFieldSet
-                defaults={defaults}
-                fieldSet={fieldSet}
-                form={form}
-                formManager={this.formManager}
-                model={model}
-              />
-            </div>
-          ))}
-
-          {this.props.children}
-        </Antd.Form>
-      </Antd.Modal>
-    );
-  }
-}
-
-const WrappedFormModal = Antd.Form.create()(UnwrappedFormModal);
-
-@autoBindMethods
-@observer
-export class FormModal extends Component<IFormModalProps> {
   public static defaultProps: Partial<IFormModalProps> = {
     ...formPropsDefaults,
   };
 
+  private get modalProps () {
+    const { saveText } = this.props;
+
+    if (!this.formManager) {
+      return {};
+    }
+
+    return {
+      confirmLoading: this.formManager.saving,
+      okText: this.formManager.saving ? 'Saving...' : saveText,
+      onOk: this.formManager.onSave,
+    };
+  }
+
+  private setRefFormManager (formManager: FormManager) {
+    this.formManager = formManager;
+  }
+
   public render () {
-    return <WrappedFormModal {...this.props} />;
+    const { title, onCancel } = this.props;
+
+    return (
+      <Antd.Modal
+        onCancel={onCancel}
+        title={title}
+        visible
+        {...this.modalProps}
+      >
+        {this.props.childrenBefore}
+
+        <Form
+          setRefFormManager={this.setRefFormManager}
+          {...this.props}
+        />
+
+        {this.props.children}
+      </Antd.Modal>
+    );
   }
 }
 

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -1,23 +1,25 @@
 import React, { Component } from 'react';
+import { observable } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import { noop, omit } from 'lodash';
 
 import * as Antd from 'antd';
 
 import FormManager from '../utilities/FormManager';
 import { formPropsDefaults } from '../propsDefaults';
-import { IFormProps, ISharedComponentProps } from '../props';
+import { ISharedFormProps, ISharedComponentProps } from '../props';
 
 import Form from './Form';
 
-export interface IFormModalProps extends ISharedComponentProps, IFormProps {
+export interface IFormModalProps extends ISharedComponentProps, ISharedFormProps {
   childrenBefore?: React.ReactNode;
 }
 
 @autoBindMethods
 @observer
 class FormModal extends Component<IFormModalProps> {
-  private formManager?: FormManager;
+  @observable private formManager?: FormManager;
 
   public static defaultProps: Partial<IFormModalProps> = {
     ...formPropsDefaults,
@@ -27,7 +29,11 @@ class FormModal extends Component<IFormModalProps> {
     const { saveText } = this.props;
 
     if (!this.formManager) {
-      return {};
+      return {
+        confirmLoading: true,
+        okText: saveText,
+        onOk: noop,
+      };
     }
 
     return {
@@ -42,7 +48,8 @@ class FormModal extends Component<IFormModalProps> {
   }
 
   public render () {
-    const { title, onCancel } = this.props;
+    const { title, onCancel } = this.props
+      , HANDLED_PROPS = ['title', 'children', 'childrenBefore'];
 
     return (
       <Antd.Modal
@@ -55,7 +62,8 @@ class FormModal extends Component<IFormModalProps> {
 
         <Form
           setRefFormManager={this.setRefFormManager}
-          {...this.props}
+          showControls={false}
+          {...omit(this.props, HANDLED_PROPS)}
         />
 
         {this.props.children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { default as ArrayCard } from './components/ArrayCard';
 export { default as Card } from './components/Card';
 export { default as EditableArrayCard } from './components/EditableArrayCard';
 export { default as EditableCard } from './components/EditableCard';
+export { default as Form } from './components/Form';
 export { default as FormCard } from './components/FormCard';
 export { default as FormDrawer } from './components/FormDrawer';
 export { default as FormModal } from './components/FormModal';

--- a/src/props.ts
+++ b/src/props.ts
@@ -20,6 +20,7 @@ export { IEditableCardProps } from './components/EditableCard';
 export { IFormCardProps } from './components/FormCard';
 export { IFormDrawerProps } from './components/FormDrawer';
 export { IFormModalProps } from './components/FormModal';
+export { IFormProps } from './components/Form';
 export { ISummaryCardProps } from './components/SummaryCard';
 
 // Form inputs
@@ -51,7 +52,7 @@ export interface IWrappedFormProps {
   form: IForm;
 }
 
-export interface IFormProps {
+export interface ISharedFormProps {
   defaults?: object;
   isGuarded?: boolean;
   onCancel: () => void;

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -11,6 +11,7 @@ import {
   Card,
   EditableArrayCard,
   EditableCard,
+  Form,
   FormCard,
   FormDrawer,
   FormModal,
@@ -147,11 +148,15 @@ export const summaryCardPropsFactory = new Factory()
   .attrs({
   });
 
-export const formCardPropsFactory = new Factory()
+export const formPropsFactory = new Factory()
   .extend(cardPropsFactory)
   .attrs({
     onSave,
   });
+
+export const formCardPropsFactory = new Factory()
+  .extend(formPropsFactory)
+  .attrs({});
 
 export const editableCardPropsFactory = new Factory()
   .extend(cardPropsFactory)
@@ -220,6 +225,7 @@ interface IComponentGenerators {
 }
 
 export const COMPONENT_GENERATORS: IComponentGenerators = {
+  Form: { Component: Form, propsFactory: formPropsFactory },
   ArrayCard: { Component: ArrayCard, propsFactory: arrayCardPropsFactory },
   Card: { Component: Card, propsFactory: cardPropsFactory },
   EditableArrayCard: { Component: EditableArrayCard, propsFactory: editableArrayCardPropsFactory },

--- a/test/features/colProps.test.tsx
+++ b/test/features/colProps.test.tsx
@@ -5,6 +5,7 @@ import { Tester } from '@mighty-justice/tester';
 import { COMPONENT_GENERATORS } from '../factories';
 
 const SUPPORTING_COMPONENTS = [
+  'Form',
   'FormCard',
 ];
 

--- a/test/features/rowProps.test.tsx
+++ b/test/features/rowProps.test.tsx
@@ -4,6 +4,7 @@ import { Tester } from '@mighty-justice/tester';
 import { COMPONENT_GENERATORS } from '../factories';
 
 const SUPPORTING_COMPONENTS = [
+  'Form',
   'FormCard',
 ];
 

--- a/test/utilities/FormManager.test.tsx
+++ b/test/utilities/FormManager.test.tsx
@@ -14,7 +14,7 @@ async function getFormManager (fieldSets: IFieldSetPartial[], model = {}) {
   };
 
   const tester = await new Tester(FormCard, { props }).mount();
-  return tester.find('UnwrappedFormCard').instance().formManager;
+  return tester.find('UnwrappedForm').instance().formManager;
 }
 
 describe('FormManager', () => {


### PR DESCRIPTION
- Created standard `Form` component
- Changed components `FormCard`, `FormDrawer`, `FormModal` to use `Form`

## FormCard

- Form layout changed to vertical, removing label spacing and `:`
- Form controls aligned right
- Horizontal rule added over form controls

### Before:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52870860-ca06de00-3116-11e9-9fe5-b5bbccb21f2c.png" />

### After:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52870868-d0955580-3116-11e9-8c15-31b6e940e0d3.png" />

## FormDrawer

- Form controls aligned right
- Now properly implements `saveText`

### Before:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52870908-ec006080-3116-11e9-9e7a-b57453dde9dc.png" />

### After:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52870917-f02c7e00-3116-11e9-83b5-4bae9596dc30.png" />

## FormModal

- Form layout changed to vertical, removing label spacing and `:`

### Before:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52871942-34208280-3119-11e9-8a24-67cefdcd2b68.png" />

### After:
<img width="48%" src="https://user-images.githubusercontent.com/796717/52871948-38e53680-3119-11e9-9a94-0b9727dec901.png" />
