### PR TITLE
Fix ObjectSearchCreate search state bugs

### DIFF
--- a/src/inputs/ObjectSearchCreateSearchInput.tsx
+++ b/src/inputs/ObjectSearchCreateSearchInput.tsx
@@ -167,12 +167,27 @@ class ObjectSearchCreateSearchInput extends Component<IObjectSearchProps> {
   }
 
   private onChange (selectedOption: any) {
-    if (selectedOption.key === ITEM_KEYS.ADD) {
-      this.props.onAddNew(this.search);
+    const { onChange, onAddNew } = this.injected;
+
+    // Clear
+    if (!selectedOption) {
+      onChange(selectedOption);
+      return;
     }
 
+    // Add new
+    if (selectedOption.key === ITEM_KEYS.ADD) {
+      onAddNew(this.search);
+      return;
+    }
+
+    // Select from search
     const foundOption = this.options.find(option => option.id === selectedOption.key);
-    this.injected.onChange(toJS(foundOption));
+    onChange(toJS(foundOption));
+  }
+
+  private onBlur () {
+    this.search = '';
   }
 
   private onFocus () {
@@ -198,6 +213,7 @@ class ObjectSearchCreateSearchInput extends Component<IObjectSearchProps> {
         id={id}
         labelInValue
         loading={this.isLoading.isTrue}
+        onBlur={this.onBlur}
         onChange={this.onChange}
         onFocus={this.onFocus}
         onSearch={this.debouncedHandleSearch}

--- a/stories/types.stories.tsx
+++ b/stories/types.stories.tsx
@@ -37,7 +37,7 @@ storiesOf('Types', module)
               ...objectSearchCreateFactory.build() as IFieldConfigObjectSearchCreate,
               colProps: { sm: 24, lg: 12 },
               createFields: [
-                { field: 'first_name', populateFromSearch: true },
+                { field: 'first_name', populateNameFromSearch: true },
                 { field: 'last_name', populateNameFromSearch: true },
                 { field: 'lawfirm', populateFromSearch: true },
                 {

--- a/test/types/objectSearchCreate.test.tsx
+++ b/test/types/objectSearchCreate.test.tsx
@@ -41,12 +41,6 @@ async function getTester (props: any) {
   return (await new Tester(FormCard, { props }).mount());
 }
 
-function changeInputNoBlur (tester: any, selector: string, value: string) {
-  const component = tester.find(selector).first();
-  component.simulate('focus');
-  component.simulate('change', { target: { value } });
-}
-
 async function searchFor (tester: any, field: string, result: any, searchTerm: string) {
   tester.endpoints['/legal-organizations/'] = { results: [result] };
 

--- a/test/types/objectSearchCreate.test.tsx
+++ b/test/types/objectSearchCreate.test.tsx
@@ -41,9 +41,20 @@ async function getTester (props: any) {
   return (await new Tester(FormCard, { props }).mount());
 }
 
+function changeInputNoBlur (tester: any, selector: string, value: string) {
+  const component = tester.find(selector).first();
+  component.simulate('focus');
+  component.simulate('change', { target: { value } });
+}
+
 async function searchFor (tester: any, field: string, result: any, searchTerm: string) {
   tester.endpoints['/legal-organizations/'] = { results: [result] };
-  tester.changeInput(`input#${field}`, searchTerm);
+
+  // Change input without blurring
+  const component = tester.find(`input#${field}`).first();
+  component.simulate('focus');
+  component.simulate('change', { target: { value: searchTerm } });
+
   await tester.refresh();
   expect(tester.find('li').first().text()).toContain(result.name);
 }


### PR DESCRIPTION
Closes https://github.com/mighty-justice/fields-ant/issues/96
> ObjectSearchCreate does not update value in form state on clear #96

Closes https://github.com/mighty-justice/fields-ant/issues/95
> ObjectSearchCreate visually clears search on de-focus, but not in state #95 
