### PR TITLE
Allow OSC to render children

### DIFF
--- a/src/building-blocks/ButtonToolbar.tsx
+++ b/src/building-blocks/ButtonToolbar.tsx
@@ -6,7 +6,6 @@ import { Form } from 'antd';
 
 export interface IButtonToolbarProps {
   align?: 'between' | 'right';
-  children?: React.ReactNode;
   className?: any;
   fixed?: boolean;
   noSpacing?: boolean;

--- a/src/building-blocks/ButtonToolbar.tsx
+++ b/src/building-blocks/ButtonToolbar.tsx
@@ -6,7 +6,7 @@ import { Form } from 'antd';
 
 export interface IButtonToolbarProps {
   align?: 'between' | 'right';
-  children?: any;
+  children?: React.ReactNode;
   className?: any;
   fixed?: boolean;
   noSpacing?: boolean;

--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -128,6 +128,7 @@ class ObjectSearchCreate extends Component<IObjectSearchCreateProps> {
             ? this.renderAddNew()
             : this.renderSearch()
         }
+        {this.props.children}
       </div>
     );
   }


### PR DESCRIPTION
## JIRA
https://thatsmighty.atlassian.net/browse/REG-196
Note: At the beginning I wanted that for any fields-ant fields, but I don't think it make much sense for things like <Input />s, <RadioButton />s.

The goal is for OSC to display extra data when an item is selected, which is more likely to happen with OSC vs anything else.

![screen shot 2019-02-27 at 10 19 19 am](https://user-images.githubusercontent.com/1119991/53501410-1ab4fa00-3a7a-11e9-9dcf-336244565656.png)
