### PR TITLE
OSC Props fix + fix custom rendered option item selection display

### DIFF
--- a/src/inputs/ObjectSearchCreateSearchInput.tsx
+++ b/src/inputs/ObjectSearchCreateSearchInput.tsx
@@ -161,6 +161,7 @@ class ObjectSearchCreateSearchInput extends Component<IObjectSearchProps> {
         className={className}
         key={option.id}
         value={option.id}
+        title={option.name}
       >
         {renderOption ? renderOption(option) : option.name}
       </Antd.Select.Option>
@@ -220,6 +221,7 @@ class ObjectSearchCreateSearchInput extends Component<IObjectSearchProps> {
         onChange={this.onChange}
         onFocus={this.onFocus}
         onSearch={this.debouncedHandleSearch}
+        optionLabelProp='title'
         placeholder='Search...'
         showSearch
         suffixIcon={this.isLoading.isTrue ? this.loadingIcon : this.searchIcon}

--- a/src/inputs/ObjectSearchCreateSearchInput.tsx
+++ b/src/inputs/ObjectSearchCreateSearchInput.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { observable, toJS } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
-import { pick, debounce, get } from 'lodash';
+import { omit, debounce, get } from 'lodash';
 
 import * as Antd from 'antd';
 import { SelectProps } from 'antd/lib/select';
@@ -91,13 +91,15 @@ class ObjectSearchCreateSearchInput extends Component<IObjectSearchProps> {
   }
 
   private get selectProps () {
-    // Handpicking specific props to avoid unintentional behaviors
-    return pick(this.props.selectProps as SelectProps, [
-      'className',
-      'clearIcon',
-      'placeholder',
-      'removeIcon',
-      'suffixIcon',
+    // Omitting specific props to avoid unintentional behaviors
+    return omit(this.props.selectProps as SelectProps, [
+      'id',
+      'loading',
+      'onBlur',
+      'onChange',
+      'onFocus',
+      'onSearch',
+      'showSearch',
     ]);
   }
 


### PR DESCRIPTION
## Screenshot
![select-fix-props](https://user-images.githubusercontent.com/1119991/53516849-47c5d480-3a9b-11e9-964c-28131d7ce054.gif)


The`optionLabelProp` thing is fixing this issue :

![select-rendered-issue](https://user-images.githubusercontent.com/1119991/53516950-878cbc00-3a9b-11e9-87a8-bbc5f21bc6fe.gif)
