### PR TITLE
Filter readOnly and insertIf values from model on submit

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -18,7 +18,7 @@ import { IFieldConfigPartial, IFieldSet } from '../interfaces';
 import { IForm, IModel } from '../props';
 
 import backendValidation from './backendValidation';
-import { fillInFieldConfig, getFieldSetsFields } from './common';
+import { fillInFieldConfig, filterInsertIf, getFieldSetsFields } from './common';
 
 interface IArgs {
   defaults: IModel;
@@ -115,6 +115,22 @@ class FormManager {
     return formValues;
   }
 
+  public get submitModel (): IModel {
+    const submitModel: IModel = {};
+
+    this.fieldConfigs
+      .filter(fieldConfig => !filterInsertIf(fieldConfig, this.formModel))
+      .filter(fieldConfig => !fieldConfig.readOnly)
+      .forEach(fieldConfig => {
+        const { field } = fieldConfig
+          , value = get(this.formModel, field);
+
+        set(submitModel, field, value);
+      });
+
+    return submitModel;
+  }
+
   private get formValues () {
     return this.form.getFieldsValue();
   }
@@ -161,7 +177,7 @@ class FormManager {
       if (errors) { this.saving = false; return; }
 
       try {
-        await onSave(this.formModel);
+        await onSave(this.submitModel);
         this.onSuccess();
         this.form.resetFields();
       }

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -116,7 +116,7 @@ class FormManager {
   }
 
   public get submitModel (): IModel {
-    const submitModel: IModel = {};
+    const submitValues: IModel = {};
 
     this.fieldConfigs
       .filter(fieldConfig => !filterInsertIf(fieldConfig, this.formModel))
@@ -125,10 +125,10 @@ class FormManager {
         const { field } = fieldConfig
           , value = get(this.formModel, field);
 
-        set(submitModel, field, value);
+        set(submitValues, field, value);
       });
 
-    return submitModel;
+    return submitValues;
   }
 
   private get formValues () {

--- a/test/features/insertIf.test.tsx
+++ b/test/features/insertIf.test.tsx
@@ -196,4 +196,16 @@ describe('insertIf', () => {
       expect(tester.text().includes(exampleLabel)).toBe(secondExampleField);
     }
   });
+
+  it('Does not pass removed field on save', async () => {
+    const onSave = jest.fn().mockResolvedValue({})
+      , tester = await new Tester(EditableCard, { props: {
+        fieldSets: [[{ field, insertIf: jest.fn(_values => false) }]],
+        onSave,
+      }}).mount();
+    tester.click('button.btn-edit');
+    tester.submit();
+
+    expect(onSave).not.toHaveBeenCalledWith(expect.objectContaining({[field]: ''}));
+  });
 });

--- a/test/features/readWriteOnly.test.tsx
+++ b/test/features/readWriteOnly.test.tsx
@@ -1,0 +1,50 @@
+import { Tester } from '@mighty-justice/tester';
+import { COMPONENT_GENERATORS, fakeField, fakeTextShort } from '../factories';
+
+const readOnly = { type: 'string', field: fakeField(), readOnly: true, label: fakeTextShort() }
+  , writeOnly = { type: 'string', field: fakeField(), writeOnly: true, label: fakeTextShort() }
+  , normal = { type: 'string', field: fakeField(), label: fakeTextShort() }
+  , WRITE_COMPONENTS = [
+    'FormCard',
+  ]
+  , READ_COMPONENTS = [
+    'Card',
+  ]
+  ;
+
+describe('Renders', () => {
+  WRITE_COMPONENTS.forEach(componentName => {
+    it(`Shows writeOnly but not readOnly in ${componentName}`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName]
+        , onSave = jest.fn()
+        , props = propsFactory.build({ onSave, fieldSets: [[readOnly, writeOnly, normal]] })
+        , tester = await new Tester(ComponentClass, { props }).mount()
+        ;
+
+      expect(tester.text()).toContain(normal.label);
+      expect(tester.text()).toContain(writeOnly.label);
+      expect(tester.text()).not.toContain(readOnly.label);
+
+      tester.submit();
+      const submitData = onSave.mock.calls[0][0];
+
+      expect(submitData[normal.field]).toBe('');
+      expect(submitData[writeOnly.field]).toBe('');
+      expect(submitData[readOnly.field]).toBe(undefined);
+    });
+  });
+
+  READ_COMPONENTS.forEach(componentName => {
+    it(`Shows readOnly but not writeOnly in ${componentName}`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName]
+        , onSave = jest.fn()
+        , props = propsFactory.build({ onSave, fieldSets: [[readOnly, writeOnly, normal]] })
+        , tester = await new Tester(ComponentClass, { props }).mount()
+        ;
+
+      expect(tester.text()).toContain(normal.label);
+      expect(tester.text()).not.toContain(writeOnly.label);
+      expect(tester.text()).toContain(readOnly.label);
+    });
+  });
+});

--- a/test/features/readWriteOnly.test.tsx
+++ b/test/features/readWriteOnly.test.tsx
@@ -1,9 +1,9 @@
 import { Tester } from '@mighty-justice/tester';
 import { COMPONENT_GENERATORS, fakeField, fakeTextShort } from '../factories';
 
-const readOnly = { type: 'string', field: fakeField(), readOnly: true, label: fakeTextShort() }
-  , writeOnly = { type: 'string', field: fakeField(), writeOnly: true, label: fakeTextShort() }
-  , normal = { type: 'string', field: fakeField(), label: fakeTextShort() }
+const readOnly = { field: fakeField(), label: fakeTextShort(), readOnly: true, type: 'string' }
+  , writeOnly = { field: fakeField(), label: fakeTextShort(), writeOnly: true, type: 'string' }
+  , normal = { field: fakeField(), label: fakeTextShort(), type: 'string' }
   , WRITE_COMPONENTS = [
     'FormCard',
   ]


### PR DESCRIPTION
### formModel including empty id field even if readOnly is true #123 
- Added failing test

### { value: true } not being respected in boolean fieldConfig #122


### insertIf passes removed field value on save #121
- Added failing test
