### PR TITLE
Add Birthdate type / component

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,5 +4,6 @@ export const CX_PREFIX_SEARCH_CREATE = 'ant-input-search-create';
 
 export const REGEXP_SSN = /^[0-9]{3}[-\s]?[0-9]{2}[-\s]?[0-9]{4}$/;
 export const REGEXP_PHONE = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+export const REGEXP_DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 
 export const ID_ATTR = 'id';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,6 +4,5 @@ export const CX_PREFIX_SEARCH_CREATE = 'ant-input-search-create';
 
 export const REGEXP_SSN = /^[0-9]{3}[-\s]?[0-9]{2}[-\s]?[0-9]{4}$/;
 export const REGEXP_PHONE = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
-export const REGEXP_DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 
 export const ID_ATTR = 'id';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,6 +3,5 @@ export const DEFAULT_DEBOUNCE_WAIT = 300;
 export const CX_PREFIX_SEARCH_CREATE = 'ant-input-search-create';
 
 export const REGEXP_SSN = /^[0-9]{3}[-\s]?[0-9]{2}[-\s]?[0-9]{4}$/;
-export const REGEXP_PHONE = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
 
 export const ID_ATTR = 'id';

--- a/src/inputs/Birthdate.tsx
+++ b/src/inputs/Birthdate.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import moment from 'moment';
 
 import * as Antd from 'antd';
 
@@ -9,55 +10,56 @@ import {
   IInjected,
   IInputProps,
 } from '../interfaces';
+import { varToLabel } from '@mighty-justice/utils';
 
-type IField = 'years' | 'date' | 'months';
+type IField = 'year' | 'day' | 'month';
 
 interface IValueObject {
-  years: string;
-  date: string;
-  months: string;
+  year: string;
+  day: string;
+  month: string;
 }
 
 interface IInputConfig {
-  placeholder: string;
   padStart: number;
   style: { width: string, marginRight?: string };
 }
 
+export function isValidDate (value: string) {
+  return !!value && value.length === '####-##-##'.length && moment(value).isValid();
+}
+
 const inputConfig: {
-  date: IInputConfig,
-  months: IInputConfig,
-  years: IInputConfig,
+  day: IInputConfig,
+  month: IInputConfig,
+  year: IInputConfig,
 } = {
-  date: {
+  day: {
     padStart: 2,
-    placeholder: 'Day',
     style: { width: '23%', marginRight: '3%' },
   },
-  months: {
+  month: {
     padStart: 2,
-    placeholder: 'Month',
     style: { width: '23%', marginRight: '3%' },
   },
-  years: {
+  year: {
     padStart: 0,
-    placeholder: 'Year',
     style: { width: '48%' },
   },
 };
 
 @autoBindMethods
 @observer
-class Birthdate extends Component<IInputProps> {
+class Birthday extends Component<IInputProps> {
   private get injected () {
     return this.props as IInjected & IInputProps & IAntFormField;
   }
 
   private get valueObject (): IValueObject {
     const { value } = this.injected
-      , [years, months, date] = value.split('-');
+      , [year, month, day] = value.split('-');
 
-    return { years, months, date };
+    return { year, month, day };
   }
 
   private getValueField (field: IField) {
@@ -69,14 +71,15 @@ class Birthdate extends Component<IInputProps> {
         ...this.valueObject,
         [field]: inputValue && inputValue.padStart(inputConfig[field].padStart, '0'),
       }
-      , { years, date, months } = valueObject;
+      , { year, day, month } = valueObject;
 
-    const value = [years, months, date].join('-');
+    const value = [year, month, day].join('-');
     this.injected.onChange(value);
   }
 
   private renderFieldInput (field: IField) {
-    const { style, placeholder } = inputConfig[field]
+    const { style } = inputConfig[field]
+      , placeholder = varToLabel(field)
       , defaultValue = this.getValueField(field)
       , onChange = (event: any) => this.onChange(field, event.target.value)
       ;
@@ -96,12 +99,12 @@ class Birthdate extends Component<IInputProps> {
   public render () {
     return (
       <Antd.Input.Group compact>
-        {this.renderFieldInput('months')}
-        {this.renderFieldInput('date')}
-        {this.renderFieldInput('years')}
+        {this.renderFieldInput('month')}
+        {this.renderFieldInput('day')}
+        {this.renderFieldInput('year')}
       </Antd.Input.Group>
     );
   }
 }
 
-export default Birthdate;
+export default Birthday;

--- a/src/inputs/Birthdate.tsx
+++ b/src/inputs/Birthdate.tsx
@@ -78,7 +78,8 @@ class Birthday extends Component<IInputProps> {
   }
 
   private renderFieldInput (field: IField) {
-    const { style } = inputConfig[field]
+    const { id } = this.injected
+      , { style } = inputConfig[field]
       , placeholder = varToLabel(field)
       , defaultValue = this.getValueField(field)
       , onChange = (event: any) => this.onChange(field, event.target.value)
@@ -88,7 +89,7 @@ class Birthday extends Component<IInputProps> {
       <span style={{ display: 'inline-block', ...style }}>
         <Antd.Input
           defaultValue={defaultValue}
-          id={field}
+          id={[id, field].join('.')}
           onChange={onChange}
           placeholder={placeholder}
         />

--- a/src/inputs/Birthdate.tsx
+++ b/src/inputs/Birthdate.tsx
@@ -1,0 +1,113 @@
+import React, { Component } from 'react';
+import moment from 'moment';
+import { isNumber } from 'lodash';
+
+import * as Antd from 'antd';
+
+import {
+  IAntFormField,
+  IInjected,
+  IInputProps,
+} from '../interfaces';
+
+interface IInputConfig {
+  max: number;
+  min: number;
+  placeholder: string;
+  // style: { width: string };
+}
+
+const inputConfig: { [key: string]: IInputConfig } = {
+  date: {
+    max: 31,
+    min: 1,
+    placeholder: 'Day',
+    // style: { width: '25%' },
+  },
+  months: {
+    max: 12,
+    min: 1,
+    placeholder: 'Month',
+    // style: { width: '25%' },
+  },
+  years: {
+    max: 3000,
+    min: 1000,
+    placeholder: 'Year',
+    // style: { width: '50%' },
+  },
+};
+
+class Birthdate extends Component<IInputProps> {
+  private get injected () {
+    return this.props as IInjected & IInputProps & IAntFormField;
+  }
+
+  private get value () {
+    return this.injected.value as moment.Moment | null;
+  }
+
+  private static isWAT (field: string, fieldValue: number) {
+    // This function is for dealing with a JS WAT
+    // https://www.destroyallsoftware.com/talks/wat
+
+    // Months start with zero in JS because of Java
+    // https://stackoverflow.com/a/41992352/224873
+    // Months start with zero in Java because of C
+    // Months start with zero in C because of array indexing
+    // Arrays start with zero because of pointer math
+    return field === 'months' && isNumber(fieldValue);
+  }
+
+  private getValueField (field: string) {
+    const { value } = this.injected
+      , fieldValue = value && value.toObject()[field]
+      , numVal = Birthdate.isWAT(field, fieldValue) ? fieldValue + 1 : fieldValue
+      ;
+
+    return numVal && numVal.toString();
+  }
+
+  private onChange (field: string, inputValue: string) {
+    const valueObject = !!this.value ? this.value.toObject() : {}
+      , fieldValue = Number(inputValue)
+      , adjustedValue = fieldValue && Birthdate.isWAT(field, fieldValue) ? fieldValue - 1 : fieldValue;
+
+    console.log({ field, adjustedValue, valueObject });
+    console.log(moment({ ...valueObject, [field]: adjustedValue }))
+
+    this.injected.onChange(moment({
+      ...valueObject,
+      [field]: adjustedValue,
+    }));
+  }
+
+  private getInputProps (field: string) {
+    return {
+      ...inputConfig[field],
+      defaultValue: this.getValueField(field),
+      id: field,
+      onChange: (event: any) => this.onChange(field, event.target.value),
+    };
+  }
+
+  public render () {
+    return (
+      <>
+        <Antd.Input.Group compact>
+          <span style={{ display: 'inline-block', width: '23%', marginRight: '3%' }}>
+            <Antd.Input {...this.getInputProps('months')} />
+          </span>
+          <span style={{ display: 'inline-block', width: '23%', marginRight: '3%' }}>
+            <Antd.Input {...this.getInputProps('date')} />
+          </span>
+          <span style={{ display: 'inline-block', width: '48%' }}>
+            <Antd.Input {...this.getInputProps('years')} />
+          </span>
+        </Antd.Input.Group>
+      </>
+    );
+  }
+}
+
+export default Birthdate;

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -26,14 +26,14 @@ import {
   parseAndPreserveNewlines,
 } from '@mighty-justice/utils';
 
+import Birthdate, { isValidDate } from '../inputs/Birthdate';
 import ObjectSearchCreate from '../inputs/ObjectSearchCreate';
 import OptionSelect from '../inputs/OptionSelect';
 import RadioGroup from '../inputs/RadioGroup';
 import Rate, { formatRating } from '../inputs/Rate';
 import { formatOptionSelect } from '../inputs/OptionSelectDisplay';
 import { IModel, IValue } from '../props';
-import { REGEXP_PHONE, REGEXP_SSN } from '../consts';
-import Birthdate from '../inputs/Birthdate';
+import { REGEXP_SSN } from '../consts';
 
 function passRenderOnlyValue (func: (value: IValue) => React.ReactNode) {
   // tslint:disable-next-line no-unnecessary-callback-wrapper
@@ -61,10 +61,6 @@ function booleanFromForm (value: IValue) {
     }
   }
   return value;
-}
-
-function isValidDate (value: string) {
-  return !!value && value.length === '####-##-##'.length && moment(value).isValid();
 }
 
 export const TYPES: { [key: string]: Partial<IFieldConfig> } = {

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -32,7 +32,7 @@ import RadioGroup from '../inputs/RadioGroup';
 import Rate, { formatRating } from '../inputs/Rate';
 import { formatOptionSelect } from '../inputs/OptionSelectDisplay';
 import { IModel, IValue } from '../props';
-import { REGEXP_DATE, REGEXP_PHONE, REGEXP_SSN } from '../consts';
+import { REGEXP_PHONE, REGEXP_SSN } from '../consts';
 import Birthdate from '../inputs/Birthdate';
 
 function passRenderOnlyValue (func: (value: IValue) => React.ReactNode) {
@@ -63,19 +63,20 @@ function booleanFromForm (value: IValue) {
   return value;
 }
 
+function isValidDate (value: string) {
+  return !!value && value.length === '####-##-##'.length && moment(value).isValid();
+}
+
 export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
   birthdate: {
     editComponent: Birthdate,
     formValidationRules: {
       isValidDate: {
+        fieldsValidator: isValidDate,
         message: 'Must be a valid date',
-        pattern: REGEXP_DATE,
-        type: 'regexp',
       },
     },
-    fromForm: (value: any) => value && format(value, 'YYYY-MM-DD'),
     render: passRenderOnlyValue(formatDate),
-    toForm: (value: any) => (value || null) && moment(value),
   },
   boolean: {
     editComponent: OptionSelect,
@@ -176,13 +177,6 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
   },
   phone: {
     editComponent: Antd.Input,
-    formValidationRules: {
-      isPhoneNumber: {
-        message: 'Must be a valid phone number',
-        pattern: REGEXP_PHONE,
-        type: 'regexp',
-      },
-    },
     render: passRenderOnlyValue(formatPhoneNumber),
   },
   radio: {
@@ -202,7 +196,6 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
       ssn: {
         message: 'Must be a valid social security number',
         pattern: REGEXP_SSN,
-        type: 'regexp',
       },
     },
     render: passRenderOnlyValue(formatSocialSecurityNumber),

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -10,6 +10,7 @@ import {
 } from '../interfaces';
 
 import {
+  DATE_FORMATS,
   EMPTY_FIELD,
   formatCommaSeparatedNumber,
   formatDate,
@@ -31,9 +32,8 @@ import RadioGroup from '../inputs/RadioGroup';
 import Rate, { formatRating } from '../inputs/Rate';
 import { formatOptionSelect } from '../inputs/OptionSelectDisplay';
 import { IModel, IValue } from '../props';
-import { REGEXP_PHONE, REGEXP_SSN } from '../consts';
-
-import { falseyToString } from './common';
+import { REGEXP_DATE, REGEXP_PHONE, REGEXP_SSN } from '../consts';
+import Birthdate from '../inputs/Birthdate';
 
 function passRenderOnlyValue (func: (value: IValue) => React.ReactNode) {
   // tslint:disable-next-line no-unnecessary-callback-wrapper
@@ -64,6 +64,19 @@ function booleanFromForm (value: IValue) {
 }
 
 export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
+  birthdate: {
+    editComponent: Birthdate,
+    formValidationRules: {
+      isValidDate: {
+        message: 'Must be a valid date',
+        pattern: REGEXP_DATE,
+        type: 'regexp',
+      },
+    },
+    fromForm: (value: any) => value && format(value, 'YYYY-MM-DD'),
+    render: passRenderOnlyValue(formatDate),
+    toForm: (value: any) => (value || null) && moment(value),
+  },
   boolean: {
     editComponent: OptionSelect,
     fieldConfigProp: true,
@@ -75,6 +88,7 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
   },
   date: {
     editComponent: Antd.DatePicker,
+    editProps: { format: DATE_FORMATS.date },
     fromForm: (value: any) => value && format(value, 'YYYY-MM-DD'),
     render: passRenderOnlyValue(formatDate),
     toForm: (value: any) => (value || null) && moment(value),
@@ -118,7 +132,6 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
     },
     nullify: true,
     render: passRenderOnlyValue(formatMoney),
-    toForm: falseyToString,
   },
   number: {
     editComponent: Antd.Input,
@@ -140,8 +153,7 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
     render: passRenderOnlyValueAndFieldConfig(formatOptionSelect),
   },
   password: {
-    editComponent: Antd.Input,
-    editProps: { type: 'password' },
+    editComponent: Antd.Input.Password,
     render: (value) => value ? '********' : EMPTY_FIELD,
   },
   percentage: {

--- a/stories/types.stories.tsx
+++ b/stories/types.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mapValues } from 'lodash';
+import { mapValues, omit } from 'lodash';
 
 import { storiesOf } from '@storybook/react';
 import Marked from 'storybook-readme/components/Marked';
@@ -24,8 +24,9 @@ const props = {
   };
 
 storiesOf('Types', module)
-  .add('Displaying', () => <Card {...props} />)
+  .add('Creating', () => <FormCard {...formCardPropsFactory.build()} {...omit(props, 'model')} />)
   .add('Editing', () => <FormCard {...formCardPropsFactory.build()} {...props} />)
+  .add('Displaying', () => <Card {...props} />)
   .add('objectSearchCreate', () => (
     <>
       <Marked md={`# { type: 'objectSearchCreate' }`} />

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -29,6 +29,7 @@ export const fakeTextShort = () => faker.random.words(3);
 
 export const fakeBoolean = () => sample([true, false]);
 export const fakeDateRecent = () => format(faker.date.recent(), 'YYYY-MM-DD');
+export const fakeBirthdate = () => format(faker.date.past(100), 'YYYY-MM-DD');
 export const fakeDuration = () => faker.helpers.replaceSymbolWithNumber('P#Y');
 export const fakeField = () => faker.random.words(3).replace(/[^A-Za-z ]/g, '').replace(/ /g, '_').toLowerCase();
 export const fakeObjectSearchCreate = () => ({ name: fakeTextShort(), id: faker.random.uuid() });
@@ -56,6 +57,7 @@ export function fieldFactoryForType (type: string) {
     .attrs({ type });
 }
 
+export const birthdateFactory = fieldFactoryForType('birthdate');
 export const booleanFactory = fieldFactoryForType('boolean');
 export const dateFactory = fieldFactoryForType('date');
 export const durationFactory = fieldFactoryForType('duration');
@@ -176,6 +178,7 @@ interface ITypeGenerators {
 }
 
 export const TYPE_GENERATORS: ITypeGenerators = {
+  birthdate: { valueFunction: fakeBirthdate, fieldConfigFactory: birthdateFactory },
   boolean: { valueFunction: fakeBoolean, fieldConfigFactory: booleanFactory },
   date: { valueFunction: fakeDateRecent, fieldConfigFactory: dateFactory },
   duration: { valueFunction: fakeDuration, fieldConfigFactory: durationFactory },
@@ -205,6 +208,7 @@ export const valueRenderPairs: { [key: string]: [IValue, string | null] } = {
     return [type, [value, value]];
   })),
 
+  birthdate: ['2017-11-22', '11/22/17'],
   boolean: sample([[true, 'Yes'], [false, 'No']]) as [boolean, string],
   date: ['2017-11-22', '11/22/17'],
   hidden: [TYPE_GENERATORS.hidden.valueFunction(), SKIP],

--- a/test/types/birthdate.test.tsx
+++ b/test/types/birthdate.test.tsx
@@ -1,0 +1,25 @@
+import faker from 'faker';
+import { Tester } from '@mighty-justice/tester';
+
+import { FormCard } from '../../src';
+import { TYPE_GENERATORS } from '../factories';
+
+describe('birthdate', () => {
+  it('Edits', async () => {
+    const { valueFunction, fieldConfigFactory } = TYPE_GENERATORS.birthdate
+      , value = valueFunction()
+      , newDay = faker.random.number({ min: 1, max: 9 }).toString().padStart(2)
+      , newValue = value.substr(0, 8) + newDay
+      , fieldConfig = fieldConfigFactory.build()
+      , fieldSets = [[fieldConfig]]
+      , model = { [fieldConfig.field]: value }
+      , onSave = jest.fn()
+      , props = { fieldSets, model, onSave }
+      ;
+
+    const tester = await new Tester(FormCard, { props }).mount();
+    tester.changeInput(`input[id="${fieldConfig.field}.day"]`, newDay);
+    tester.submit();
+    expect(onSave).toHaveBeenCalledWith({ [fieldConfig.field]: newValue });
+  });
+});

--- a/test/utilities/FormManager.test.tsx
+++ b/test/utilities/FormManager.test.tsx
@@ -4,7 +4,6 @@ import * as Antd from 'antd';
 import { Tester } from '@mighty-justice/tester';
 
 import { FormCard, IFieldSetPartial } from '../../src';
-import { toastError } from '../../src/utilities/FormManager';
 
 async function getFormManager (fieldSets: IFieldSetPartial[], model = {}) {
   const props = {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/796717/55588168-132ce480-56fb-11e9-84dd-3dc6e2e5164f.png)


My initial version of this included this function I loved but removed after a much better implementation:

```ts
  private static isWAT (field: string, fieldValue: number) {
    // This function is for dealing with a JS WAT
    // https://www.destroyallsoftware.com/talks/wat

    // Months start with zero in JS because of Java
    // https://stackoverflow.com/a/41992352/224873
    // Months start with zero in Java because of C
    // Months start with zero in C because of array indexing
    // Arrays start with zero because of pointer math
    return field === 'months' && isNumber(fieldValue);
  }
```