### PR TITLE
Allow complex nested field sets

### DIFF
--- a/src/building-blocks/NestedFieldSet.tsx
+++ b/src/building-blocks/NestedFieldSet.tsx
@@ -8,9 +8,9 @@ import { splitName } from '@mighty-justice/utils';
 import {
   fillInFieldSet,
   FormFieldSet,
-  getFieldSetFields,
   IFieldConfigPartial,
   IFieldSetPartial,
+  mapFieldSetFields,
 } from '../';
 
 import FormManager from '../utilities/FormManager';
@@ -26,15 +26,20 @@ export interface INestedFieldSetProps {
 @autoBindMethods
 @observer
 class NestedFieldSet extends Component<INestedFieldSetProps> {
+  private fieldValueMapper (fieldConfig: IFieldConfigPartial) {
+    const { id } = this.props;
+
+    return {
+      ...fieldConfig,
+      field: `${id}.${fieldConfig.field}`,
+      ...this.getDefaultValue(fieldConfig),
+    };
+  }
+
   @computed
   private get fieldSet () {
-    const { id, fieldSet } = this.props;
-    return getFieldSetFields(fillInFieldSet(fieldSet))
-      .map(fieldConfig => ({
-        ...fieldConfig,
-        field: `${id}.${fieldConfig.field}`,
-        ...this.getDefaultValue(fieldConfig),
-      }));
+    const { fieldSet } = this.props;
+    return mapFieldSetFields(fillInFieldSet(fieldSet), this.fieldValueMapper);
   }
 
   private getDefaultValue (fieldConfig: IFieldConfigPartial): object {

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -165,14 +165,7 @@ export function mapFieldSetFields (fieldSet: IFieldSetPartial, mapper: IMapper):
 
 export function fillInFieldSet (fieldSet: IFieldSetPartial): IFieldSet {
   // Fills in the defaults from common so we can keep configurations light
-  if (isPartialFieldSetSimple(fieldSet)) {
-    return fieldSet.map(fillInFieldConfig);
-  }
-
-  return {
-    ...fieldSet,
-    fields: fieldSet.fields.map(fillInFieldConfig),
-  };
+  return mapFieldSetFields(fieldSet, fillInFieldConfig) as IFieldSet;
 }
 
 export function fillInFieldSets (fieldSets: IFieldSetPartial[]): IFieldSet[] {

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -150,8 +150,9 @@ export function fillInFieldConfig (fieldConfig: IFieldConfigPartial): IFieldConf
   };
 }
 
-export function mapFieldSetFields (fieldSet: IFieldSetPartial,
-                                   mapper: (fields: IFieldConfigPartial) => IFieldConfigPartial): IFieldSetPartial {
+type IMapper = (fields: IFieldConfigPartial) => IFieldConfigPartial;
+
+export function mapFieldSetFields (fieldSet: IFieldSetPartial, mapper: IMapper): IFieldSetPartial {
   if (isPartialFieldSetSimple(fieldSet)) {
     return fieldSet.map(mapper);
   }

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -150,6 +150,18 @@ export function fillInFieldConfig (fieldConfig: IFieldConfigPartial): IFieldConf
   };
 }
 
+export function mapFieldSetFields (fieldSet: IFieldSetPartial,
+                                   mapper: (fields: IFieldConfigPartial) => IFieldConfigPartial): IFieldSetPartial {
+  if (isPartialFieldSetSimple(fieldSet)) {
+    return fieldSet.map(mapper);
+  }
+
+  return {
+    ...fieldSet,
+    fields: fieldSet.fields.map(mapper),
+  };
+}
+
 export function fillInFieldSet (fieldSet: IFieldSetPartial): IFieldSet {
   // Fills in the defaults from common so we can keep configurations light
   if (isPartialFieldSetSimple(fieldSet)) {

--- a/test/types/objectSearchCreate.test.tsx
+++ b/test/types/objectSearchCreate.test.tsx
@@ -3,6 +3,7 @@ import faker from 'faker';
 import { Tester } from '@mighty-justice/tester';
 
 import { FormCard } from '../../src';
+import { fakeTextShort } from "../factories";
 
 function getDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
@@ -164,4 +165,17 @@ describe('objectSearchCreate', () => {
     expect(onSave).toHaveBeenCalledWith({ law_firm: { non_nullable: '', nullable: null }});
   });
 
+  it('Renders complex nested field sets', async () => {
+    const legend = fakeTextShort()
+      , { field, searchTerm, result, props } = getDefaults({
+        createFields: { fields: [{ field: 'complex'}], legend },
+      })
+      , tester = await getTester(props);
+
+    await searchFor(tester, field, result, searchTerm);
+    await selectAddNew(tester);
+    await tester.refresh();
+
+    expect(tester.text()).toContain(legend);
+  });
 });


### PR DESCRIPTION
Allows for `rowProps` and `legend` to be passed into `FormFieldSet`.

Fixes https://github.com/mighty-justice/fields-ant/issues/159.