### PR TITLE
ObjectSearchCreate: searchFields or endpoint changing should clear results cache

### DIFF
--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -82,19 +82,19 @@ class ObjectSearch extends Component<IObjectSearchProps> {
   }
 
   private get hasNewEndpoint () {
-    return this.previousEndpoint === this.fieldConfig.endpoint;
+    return this.previousEndpoint !== this.fieldConfig.endpoint;
   }
 
   private get hasNewSearchFilters () {
-    return this.previousSearchFilters === toKey(this.fieldConfig.searchFilters || {});
+    return this.previousSearchFilters !== toKey(this.fieldConfig.searchFilters || {});
+  }
+
+  private get hasNewProps () {
+    return this.hasNewEndpoint || this.hasNewSearchFilters;
   }
 
   private get isPristine () {
     return !this.hasOptions && !this.hasSearch;
-  }
-
-  private get hasNewProps () {
-    return !this.hasNewEndpoint || !this.hasNewSearchFilters;
   }
 
   private get loadingIcon () {

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -45,6 +45,9 @@ class ObjectSearch extends Component<IObjectSearchProps> {
   @observable private isLoading = new SmartBool();
   @observable private search = '';
 
+  @observable private previousEndpoint = '';
+  @observable private previousSearchFilters = '';
+
   public static defaultProps: Partial<IObjectSearchProps> = {
     debounceWait: DEFAULT_DEBOUNCE_WAIT,
   };
@@ -54,6 +57,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
   public constructor (props: IObjectSearchProps) {
     super(props);
     this.debouncedHandleSearch = debounce(this.handleSearch, props.debounceWait);
+    this.updateValueCaches();
   }
 
   private get injected () {
@@ -70,6 +74,28 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
   private get hasOptions () {
     return !!this.options.length;
+  }
+
+  private updateValueCaches () {
+    this.previousEndpoint = this.fieldConfig.endpoint;
+    this.previousSearchFilters = toKey(this.fieldConfig.searchFilters || {});
+  }
+
+  private get hasNewEndpoint () {
+    return this.previousEndpoint === this.fieldConfig.endpoint;
+  }
+
+  private get hasNewSearchFilters () {
+    return this.previousSearchFilters === toKey(this.fieldConfig.searchFilters || {});
+  }
+
+  private get isPristine () {
+    return (
+      !this.hasOptions
+      && !this.hasSearch
+      && !this.hasNewEndpoint
+      && !this.hasNewSearchFilters
+    );
   }
 
   private get loadingIcon () {
@@ -104,6 +130,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
     this.search = value;
     this.isLoading.setTrue();
+    this.updateValueCaches();
     const response = await getEndpoint(`/${endpoint}/${toKey(params)}`);
     this.options = response.results;
     this.isLoading.setFalse();
@@ -193,8 +220,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
   // istanbul ignore next
   private onFocus () {
-    const isPristine = !this.hasOptions && !this.hasSearch;
-    if (isPristine) {
+    if (this.isPristine) {
       // Trigger empty search
       this.handleSearch(this.search);
     }

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -90,12 +90,11 @@ class ObjectSearch extends Component<IObjectSearchProps> {
   }
 
   private get isPristine () {
-    return (
-      !this.hasOptions
-      && !this.hasSearch
-      && !this.hasNewEndpoint
-      && !this.hasNewSearchFilters
-    );
+    return !this.hasOptions && !this.hasSearch;
+  }
+
+  private get hasNewProps () {
+    return !this.hasNewEndpoint || !this.hasNewSearchFilters;
   }
 
   private get loadingIcon () {
@@ -220,7 +219,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
   // istanbul ignore next
   private onFocus () {
-    if (this.isPristine) {
+    if (this.isPristine || this.hasNewProps) {
       // Trigger empty search
       this.handleSearch(this.search);
     }

--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -95,7 +95,11 @@ class ObjectSearchCreate extends Component<IObjectSearchCreateProps> {
           label={this.fieldConfig.label}
           search={this.search}
         />
-        <Antd.Button className={`${CX_PREFIX_SEARCH_CREATE}-btn-back`} size='small' onClick={this.onSearch}>
+        <Antd.Button
+          className={`${CX_PREFIX_SEARCH_CREATE}-btn-back`}
+          onClick={this.onSearch}
+          size='small'
+        >
           <Antd.Icon type='left' /> Back to search
         </Antd.Button>
       </>

--- a/test/types/objectSearch.test.tsx
+++ b/test/types/objectSearch.test.tsx
@@ -31,7 +31,7 @@ function getDefaults (overrides?: any) {
   };
 }
 
-async function searchFor (tester: any, field: string, result: any, searchTerm: string) {
+export async function objectSearchFor (tester: any, field: string, result: any, searchTerm: string) {
   tester.endpoints['/legal-organizations/'] = { results: [result] };
 
   // Change input without blurring
@@ -45,13 +45,16 @@ async function searchFor (tester: any, field: string, result: any, searchTerm: s
 describe('objectSearch', () => {
   it('Properly caches and displays options', async () => {
     const { field, searchTerm, result, props, endpoint } = getDefaults({})
-      , tester = (await new Tester(ObjectSearch, { props }).mount() as any);
+      , tester = (await new Tester(ObjectSearch, { props }).mount() as any)
+      , newEndpoint = `${endpoint}-2`
+      ;
+
+    tester.endpoints[`/${newEndpoint}/`] = { results: [result] };
 
     expect(tester.getEndpoint.mock.calls.length).toBe(0);
 
     // First search
-    tester.endpoints['/legal-organizations/'] = { results: [result] };
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     expect(tester.getEndpoint.mock.calls.length).toBe(1);
 
     // Re-focus but no new props
@@ -59,8 +62,6 @@ describe('objectSearch', () => {
     expect(tester.getEndpoint.mock.calls.length).toBe(1);
 
     // Re-focus but with new props
-    const newEndpoint = `${endpoint}-2`;
-    tester.endpoints[newEndpoint] = { results: [result] };
     props.fieldConfig.endpoint = newEndpoint;
     tester.instance.onFocus();
     expect(tester.getEndpoint.mock.calls.length).toBe(2);

--- a/test/types/objectSearch.test.tsx
+++ b/test/types/objectSearch.test.tsx
@@ -1,0 +1,68 @@
+import faker from 'faker';
+
+import { Tester } from '@mighty-justice/tester';
+
+import { fillInFieldConfig } from '../../src';
+import ObjectSearch from '../../src/inputs/ObjectSearch';
+
+function getDefaults (overrides?: any) {
+  const fakeLawFirm = () => ({
+      id: faker.random.uuid(),
+      name: faker.company.companyName(),
+    })
+    , field = overrides.field || 'law_firm'
+    , endpoint = overrides.endpoint || 'legal-organizations'
+    , type = overrides.type || 'objectSearch'
+    , fieldConfig = fillInFieldConfig({ field, type, endpoint, ...overrides.fieldConfig })
+    , props = { id: field, fieldConfig, debounceWait: 0 }
+    ;
+
+  return {
+    result: fakeLawFirm(),
+    searchTerm: faker.lorem.sentence(),
+
+    endpoint,
+    field,
+    fieldConfig,
+    props,
+    type,
+
+    ...overrides,
+  };
+}
+
+async function searchFor (tester: any, field: string, result: any, searchTerm: string) {
+  tester.endpoints['/legal-organizations/'] = { results: [result] };
+
+  // Change input without blurring
+  const component = tester.find(`input#${field}`).first();
+  component.simulate('focus');
+  component.simulate('change', { target: { value: searchTerm } });
+
+  await tester.refresh();
+}
+
+describe('objectSearch', () => {
+  it('Properly caches and displays options', async () => {
+    const { field, searchTerm, result, props, endpoint } = getDefaults({})
+      , tester = (await new Tester(ObjectSearch, { props }).mount() as any);
+
+    expect(tester.getEndpoint.mock.calls.length).toBe(0);
+
+    // First search
+    tester.endpoints['/legal-organizations/'] = { results: [result] };
+    await searchFor(tester, field, result, searchTerm);
+    expect(tester.getEndpoint.mock.calls.length).toBe(1);
+
+    // Re-focus but no new props
+    tester.instance.onFocus();
+    expect(tester.getEndpoint.mock.calls.length).toBe(1);
+
+    // Re-focus but with new props
+    const newEndpoint = `${endpoint}-2`;
+    tester.endpoints[newEndpoint] = { results: [result] };
+    props.fieldConfig.endpoint = newEndpoint;
+    tester.instance.onFocus();
+    expect(tester.getEndpoint.mock.calls.length).toBe(2);
+  });
+});

--- a/test/types/objectSearchCreate.test.tsx
+++ b/test/types/objectSearchCreate.test.tsx
@@ -5,6 +5,8 @@ import { Tester } from '@mighty-justice/tester';
 import { FormCard } from '../../src';
 import { fakeTextShort } from '../factories';
 
+import { objectSearchFor } from './objectSearch.test';
+
 function getDefaults (overrides?: any) {
   const fakeLawFirm = () => ({
       id: faker.random.uuid(),
@@ -45,17 +47,6 @@ async function getTester (props: any) {
   return (await new Tester(FormCard, { props }).mount());
 }
 
-async function searchFor (tester: any, field: string, result: any, searchTerm: string) {
-  tester.endpoints['/legal-organizations/'] = { results: [result] };
-
-  // Change input without blurring
-  const component = tester.find(`input#${field}`).first();
-  component.simulate('focus');
-  component.simulate('change', { target: { value: searchTerm } });
-
-  await tester.refresh();
-}
-
 async function selectAddNew (tester: any) {
   tester.click('.ant-input-search-create-item-add div');
 }
@@ -69,7 +60,7 @@ describe('objectSearchCreate', () => {
     const { field, props, onSave, searchTerm, result } = getDefaults({})
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
 
     selectFirst(tester);
     tester.submit();
@@ -84,7 +75,7 @@ describe('objectSearchCreate', () => {
     expect(onSave).toHaveBeenCalledWith(props.model);
     onSave.mockClear();
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     await selectAddNew(tester);
 
     expect(tester.text()).toContain('Name');
@@ -121,7 +112,7 @@ describe('objectSearchCreate', () => {
       })
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     await selectAddNew(tester);
 
     expect(tester.find('input[id="law_firm.name"]').html()).toContain(searchTerm);
@@ -141,7 +132,7 @@ describe('objectSearchCreate', () => {
       , { field, onSave, result, props } = getDefaults({ createFields })
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     await selectAddNew(tester);
 
     expect(tester.find('input[id="law_firm.first_name"]').html()).toContain(firstName);
@@ -164,7 +155,7 @@ describe('objectSearchCreate', () => {
       })
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     await selectAddNew(tester);
     tester.submit();
 
@@ -179,7 +170,7 @@ describe('objectSearchCreate', () => {
       })
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
     await selectAddNew(tester);
     await tester.refresh();
 
@@ -208,7 +199,7 @@ describe('objectSearchCreate', () => {
       })
       , tester = await getTester(props);
 
-    await searchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, result, searchTerm);
 
     expect(tester.find('li').first().text()).toContain('FFF');
     selectFirst(tester);

--- a/test/types/objectSearchCreate.test.tsx
+++ b/test/types/objectSearchCreate.test.tsx
@@ -4,7 +4,6 @@ import { Tester } from '@mighty-justice/tester';
 
 import { FormCard } from '../../src';
 import { fakeTextShort } from '../factories';
-import ObjectSearch from '../../src/inputs/ObjectSearch';
 
 function getDefaults (overrides?: any) {
   const fakeLawFirm = () => ({
@@ -217,30 +216,5 @@ describe('objectSearchCreate', () => {
     tester.submit();
 
     expect(onSave).toHaveBeenCalledWith({ law_firm: result });
-  });
-
-  it('Properly caches and displays options', async () => {
-    const { field, searchTerm, result, props, endpoint } = getDefaults({})
-      , testerForm = await getTester(props) as any
-      , inputProps = testerForm.find('ObjectSearch').props()
-      , tester = (await new Tester(ObjectSearch, { props: inputProps }).mount() as any)
-      ;
-
-    expect(tester.getEndpoint.mock.calls.length).toBe(0);
-
-    // First search
-    testerForm.endpoints['/legal-organizations/'] = { results: [result] };
-    await searchFor(tester, field, result, searchTerm);
-    expect(testerForm.getEndpoint.mock.calls.length).toBe(1);
-
-    // Re-focus but no new props
-    tester.instance.onFocus();
-    expect(testerForm.getEndpoint.mock.calls.length).toBe(1);
-
-    // Refocus but with new props
-    testerForm.endpoints['/legal-organizations-2/'] = { results: [result] };
-    inputProps.fieldConfig.endpoint = `${endpoint}-2`;
-    tester.instance.onFocus();
-    expect(testerForm.getEndpoint.mock.calls.length).toBe(2);
   });
 });


### PR DESCRIPTION
**JIRA:** https://thatsmighty.atlassian.net/browse/MTY-962
Closes https://github.com/mighty-justice/fields-ant/issues/155
