### PR TITLE
Add formModel prop to Form sub-components for significant speed increases

### DIFF
--- a/src/building-blocks/FormField.tsx
+++ b/src/building-blocks/FormField.tsx
@@ -9,10 +9,12 @@ import { ValidationRule as AntValidationRule } from 'antd/lib/form';
 
 import { FormManager, fillInFieldConfig, renderLabel, filterFieldConfig } from '../utilities';
 import { IFieldConfigPartial, IFieldsValidator } from '../interfaces';
+import { IModel } from '../props';
 
 export interface IFormFieldProps {
   fieldConfig: IFieldConfigPartial;
   formManager: FormManager;
+  formModel: IModel;
 }
 
 @autoBindMethods
@@ -87,9 +89,9 @@ class FormField extends Component<IFormFieldProps> {
   }
 
   private get shouldRender (): boolean {
-    const { formManager } = this.props;
+    const { formModel } = this.props;
     return !filterFieldConfig(this.fieldConfig, {
-      model: formManager.formModel,
+      model: formModel,
       readOnly: true,
     });
   }

--- a/src/building-blocks/FormFieldSet.tsx
+++ b/src/building-blocks/FormFieldSet.tsx
@@ -14,6 +14,7 @@ import {
 } from '../utilities';
 
 import { IFieldSetPartial } from '../interfaces';
+import { IModel } from '../props';
 
 import FormField from './FormField';
 import Legend from './Legend';
@@ -21,6 +22,7 @@ import Legend from './Legend';
 export interface IFormFieldSetProps {
   fieldSet: IFieldSetPartial;
   formManager: FormManager;
+  formModel: IModel;
 }
 
 @autoBindMethods
@@ -31,22 +33,10 @@ class FormFieldSet extends Component<IFormFieldSetProps> {
     return fillInFieldSet(this.props.fieldSet);
   }
 
-  private get filteredFieldConfigs () {
-    // Filter out read-only fieldConfigs
-    const fieldConfigs = getFieldSetFields(this.fieldSet);
-
-    // If no fieldConfigs have an insertIf, skip costly formModel calculation
-    if (!fieldConfigs.some(fieldConfig => !!fieldConfig.insertIf)) {
-      return filterFieldConfigs(fieldConfigs, { readOnly: true });
-    }
-
-    // One of them does, so get formModel and filter out insertIfs
-    const formModel = this.props.formManager.formModel;
-    return filterFieldConfigs(fieldConfigs, { model: formModel, readOnly: true });
-  }
-
   public render () {
-    const filteredFieldConfigs = this.filteredFieldConfigs
+    const { formModel } = this.props
+      , fieldConfigs = getFieldSetFields(this.fieldSet)
+      , filteredFieldConfigs = filterFieldConfigs(fieldConfigs, { model: formModel, readOnly: true })
       , rowProps = !isFieldSetSimple(this.fieldSet) && this.fieldSet.rowProps
       ;
 

--- a/src/building-blocks/NestedFieldSet.tsx
+++ b/src/building-blocks/NestedFieldSet.tsx
@@ -14,10 +14,12 @@ import {
 } from '../';
 
 import { FormManager } from '../utilities';
+import { IModel } from '../props';
 
 export interface INestedFieldSetProps {
   fieldSet: IFieldSetPartial;
   formManager: FormManager;
+  formModel: IModel;
   id: string;
   label: React.ReactNode;
   search?: string;
@@ -79,6 +81,7 @@ class NestedFieldSet extends Component<INestedFieldSetProps> {
       <FormFieldSet
         fieldSet={this.fieldSet}
         formManager={this.props.formManager}
+        formModel={this.props.formModel}
       />
     );
   }

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -70,10 +70,6 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
-  private get filteredFieldSets (): IFieldSet[] {
-   return filterFieldSets(this.fieldSets, { model: this.formManager.formModel });
-  }
-
   private renderControls () {
     const {
         blockSubmit,
@@ -110,13 +106,15 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
   }
 
   public render () {
-    const { showControls, title } = this.props;
+    const { showControls, title } = this.props
+      , formModel = this.formManager.formModel
+      , filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel });
 
     return (
       <Antd.Form layout='vertical' onSubmit={this.formManager.onSave} className='mfa-form'>
         {title && <h2>{title}</h2>}
 
-        {this.filteredFieldSets.map((fieldSet: IFieldSet, idx: number) => (
+        {filteredFieldSets.map((fieldSet: IFieldSet, idx: number) => (
           <Fragment key={idx}>
             {(idx > 0) && <Antd.Divider key={`divider-${idx}`} />}
 
@@ -124,6 +122,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
               <FormFieldSet
                 fieldSet={fieldSet}
                 formManager={this.formManager}
+                formModel={formModel}
               />
             </div>
           </Fragment>

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -118,6 +118,11 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     ]);
   }
 
+  private async onSearch (value: string) {
+    this.isLoading.setTrue();
+    this.debouncedHandleSearch(value);
+  }
+
   private async handleSearch (value: string) {
     const { getEndpoint } = this.injected
       , { endpoint, searchFilters } = this.fieldConfig
@@ -261,7 +266,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
         onBlur={this.onBlur}
         onChange={this.onChange}
         onFocus={this.onFocus}
-        onSearch={this.debouncedHandleSearch}
+        onSearch={this.onSearch}
         optionLabelProp='title'
         placeholder={placeholder}
         showSearch

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -118,11 +118,6 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     ]);
   }
 
-  private async onSearch (value: string) {
-    this.isLoading.setTrue();
-    this.debouncedHandleSearch(value);
-  }
-
   private async handleSearch (value: string) {
     const { getEndpoint } = this.injected
       , { endpoint, searchFilters } = this.fieldConfig
@@ -266,7 +261,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
         onBlur={this.onBlur}
         onChange={this.onChange}
         onFocus={this.onFocus}
-        onSearch={this.onSearch}
+        onSearch={this.debouncedHandleSearch}
         optionLabelProp='title'
         placeholder={placeholder}
         showSearch

--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -94,6 +94,7 @@ class ObjectSearchCreate extends Component<IObjectSearchCreateProps> {
         <NestedFieldSet
           fieldSet={this.fieldConfig.createFields}
           formManager={formManager}
+          formModel={formManager.formModel}
           id={fieldConfig.field}
           label={renderLabel(this.fieldConfig)}
           search={this.search}

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -133,7 +133,7 @@ class FormManager {
       const isInForm = has(formValues, fieldConfig.field)
         , value = isInForm
           ? this.getFormValue(fieldConfig, formValues)
-          : this.getDefaultValue(fieldConfig)
+          : fieldConfig.fromForm(this.getDefaultValue(fieldConfig), fieldConfig)
         ;
 
       set(formModel, fieldConfig.field, value);

--- a/src/utilities/common.tsx
+++ b/src/utilities/common.tsx
@@ -34,8 +34,6 @@ import { filterFieldConfig } from './filters';
 // istanbul ignore next
 export async function asyncNoop () { return; }
 
-export function falseyToString (value: IValue) { return value || ''; }
-
 export function isPartialFieldSetSimple (fieldSet: IFieldSetPartial): fieldSet is IFieldSetSimplePartial {
   return isArray(fieldSet);
 }

--- a/src/utilities/fillIn.ts
+++ b/src/utilities/fillIn.ts
@@ -5,7 +5,10 @@ import { getOrDefault, varToLabel } from '@mighty-justice/utils';
 import { IFieldConfig, IFieldConfigPartial, IFieldSet, IFieldSetPartial } from '../interfaces';
 
 import { TYPES } from './types';
-import { falseyToString, mapFieldSetFields } from './common';
+import { mapFieldSetFields } from './common';
+import { IValue } from '../props';
+
+export function falseyToString (value: IValue) { return value || ''; }
 
 const typeDefaults = {
   editComponent: Antd.Input,


### PR DESCRIPTION
The changes made for https://thatsmighty.atlassian.net/browse/MTY-1035 totally destroyed the speed increases we made to support 150+ input forms. This PR brings performance back in line with before the change.

`formManager.formModel` is by far the most expensive operation when rendering. This change significantly reduces the number of times it has to be called, down to near 1 per render.