### PR TITLE
Don't require a legend on fieldSets

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -91,7 +91,7 @@ export type IFieldSetSimple = IFieldConfig[];
 
 export interface IFieldSetComplex {
   fields: IFieldSetSimple;
-  legend: string;
+  legend?: string;
   rowProps?: RowProps;
   tooltip?: string;
 }
@@ -112,7 +112,7 @@ export type IFieldSetPartial = IFieldSetSimplePartial | IFieldSetComplexPartial;
 
 export interface IFieldSetComplexPartial {
   fields: IFieldSetSimplePartial;
-  legend: string;
+  legend?: string;
   rowProps?: RowProps;
   tooltip?: string;
 }


### PR DESCRIPTION
There are situations where we want to set `rowProps` but not show a legend.