### PR TITLE
Standardize props / behavior between FormModal and FormDrawer

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -62,9 +62,8 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
   }
 
   private onSuccess () {
-    const { onSuccess, onCancel } = this.props;
+    const { onSuccess } = this.props;
     if (onSuccess) { onSuccess(); }
-    if (onCancel) { onCancel(); }
   }
 
   @computed

--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -4,38 +4,36 @@ import autoBindMethods from 'class-autobind-decorator';
 import { omit } from 'lodash';
 import cx from 'classnames';
 
-import SmartBool from '@mighty-justice/smart-bool';
-
 import * as Antd from 'antd';
 
 import { formPropsDefaults } from '../propsDefaults';
-import { ISharedFormProps, ISharedComponentProps } from '../props';
+import { ISharedFormModalProps } from '../props';
 
 import Form from './Form';
 
-export interface IFormDrawerProps extends ISharedComponentProps, ISharedFormProps {
-  isVisible: SmartBool;
-  onCancel: () => void;
-  width?: number | string;
-}
-
 @autoBindMethods
 @observer
-class FormDrawer extends Component<IFormDrawerProps> {
-  public static defaultProps: Partial<IFormDrawerProps> = {
+class FormDrawer extends Component<ISharedFormModalProps> {
+  public static defaultProps: Partial<ISharedFormModalProps> = {
     ...formPropsDefaults,
   };
 
   private onCancel () {
     const { onCancel, isVisible } = this.props;
-    onCancel();
-    isVisible.setFalse();
+    if (onCancel) { onCancel(); }
+    if (isVisible && !onCancel) { isVisible.setFalse(); }
+  }
+
+  private onSuccess () {
+    const { onSuccess, isVisible } = this.props;
+    if (onSuccess) { onSuccess(); }
+    if (isVisible && !onSuccess) { isVisible.setFalse(); }
   }
 
   public render () {
     const { className, isVisible, title, width } = this.props
       , drawerClassName = cx('mfa-form-drawer', className || null)
-      , HANDLED_PROPS = ['title', 'isVisible'];
+      , HANDLED_PROPS = ['title', 'isVisible', 'childrenBefore'];
 
     return (
       <Antd.Drawer
@@ -46,12 +44,15 @@ class FormDrawer extends Component<IFormDrawerProps> {
         onClose={this.onCancel}
         placement='right'
         title={title}
-        visible={isVisible.isTrue}
-        width={width}
+        visible={isVisible ? isVisible.isTrue : true}
+        width={width || '600px'}
       >
+        {this.props.childrenBefore}
+
         <Form
           {...omit(this.props, HANDLED_PROPS)}
           onCancel={this.onCancel}
+          onSuccess={this.onSuccess}
         />
       </Antd.Drawer>
     );

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -8,22 +8,30 @@ import * as Antd from 'antd';
 
 import { FormManager } from '../utilities';
 import { formPropsDefaults } from '../propsDefaults';
-import { ISharedFormProps, ISharedComponentProps } from '../props';
+import { ISharedFormModalProps } from '../props';
 
 import Form from './Form';
 
-export interface IFormModalProps extends ISharedComponentProps, ISharedFormProps {
-  childrenBefore?: React.ReactNode;
-}
-
 @autoBindMethods
 @observer
-class FormModal extends Component<IFormModalProps> {
+class FormModal extends Component<ISharedFormModalProps> {
   @observable private formManager?: FormManager;
 
-  public static defaultProps: Partial<IFormModalProps> = {
+  public static defaultProps: Partial<ISharedFormModalProps> = {
     ...formPropsDefaults,
   };
+
+  private onCancel () {
+    const { onCancel, isVisible } = this.props;
+    if (onCancel) { onCancel(); }
+    if (isVisible && !onCancel) { isVisible.setFalse(); }
+  }
+
+  private onSuccess () {
+    const { onSuccess, isVisible } = this.props;
+    if (onSuccess) { onSuccess(); }
+    if (isVisible && !onSuccess) { isVisible.setFalse(); }
+  }
 
   private get modalProps () {
     const { saveText } = this.props;
@@ -48,20 +56,23 @@ class FormModal extends Component<IFormModalProps> {
   }
 
   public render () {
-    const { title, onCancel } = this.props
-      , HANDLED_PROPS = ['title', 'children', 'childrenBefore'];
+    const { isVisible, title, width } = this.props
+      , HANDLED_PROPS = ['title', 'isVisible', 'children', 'childrenBefore'];
 
     return (
       <Antd.Modal
-        onCancel={onCancel}
+        onCancel={this.onCancel}
         title={title}
-        visible
+        visible={isVisible ? isVisible.isTrue : true}
+        width={width}
         {...this.modalProps}
       >
         {this.props.childrenBefore}
 
         <Form
           {...omit(this.props, HANDLED_PROPS)}
+          onCancel={this.onCancel}
+          onSuccess={this.onSuccess}
           setRefFormManager={this.setRefFormManager}
           showControls={false}
         />

--- a/src/props.ts
+++ b/src/props.ts
@@ -20,8 +20,6 @@ export { ICardProps } from './components/Card';
 export { IEditableArrayCardProps } from './components/EditableArrayCard';
 export { IEditableCardProps } from './components/EditableCard';
 export { IFormCardProps } from './components/FormCard';
-export { IFormDrawerProps } from './components/FormDrawer';
-export { IFormModalProps } from './components/FormModal';
 export { IFormProps } from './components/Form';
 export { ISummaryCardProps } from './components/SummaryCard';
 
@@ -34,6 +32,8 @@ export { IOptionSelectProps } from './inputs/OptionSelect';
 // This allows us to keep the library consistent and uniform
 
 import { IFieldSet, IFieldSetPartial } from './interfaces';
+import SmartBool from '@mighty-justice/smart-bool';
+import React from 'react';
 
 export type IClassName = any;
 export type IForm = any;
@@ -69,4 +69,10 @@ export interface ISharedFormProps {
   resetOnSuccess?: boolean;
   saveText: string;
   successText?: null | string;
+}
+
+export interface ISharedFormModalProps extends ISharedComponentProps, ISharedFormProps {
+  childrenBefore?: React.ReactNode;
+  isVisible?: SmartBool;
+  width?: number | string;
 }

--- a/src/propsDefaults.ts
+++ b/src/propsDefaults.ts
@@ -2,6 +2,5 @@ import { asyncNoop } from './utilities';
 
 export const formPropsDefaults = {
   onSave: asyncNoop,
-  onSuccess: asyncNoop,
   saveText: 'Save',
 };

--- a/test/components/FormDrawer.test.tsx
+++ b/test/components/FormDrawer.test.tsx
@@ -1,23 +1,5 @@
-import faker from 'faker';
-
-import { FormDrawer } from '../../src';
-import { Tester } from '@mighty-justice/tester';
-import SmartBool from '@mighty-justice/smart-bool';
-
 describe('FormDrawer', () => {
-  it('Renders', async () => {
-    const text = faker.lorem.sentence()
-      , title = faker.lorem.sentence()
-      , props = {
-        fieldSets: [[{ field: 'text' }]],
-        isVisible: new SmartBool(true),
-        model: { text },
-        title,
-      };
-
-    const tester = await new Tester(FormDrawer, { props }).mount();
-    expect(tester.text()).toContain(title);
-    expect(tester.text()).toContain('Text');
-    expect(tester.html()).toContain(text);
+  it('is tested the same as FormModal', async () => {
+    // See FormModal.test.tsx
   });
 });

--- a/test/components/FormModal.test.tsx
+++ b/test/components/FormModal.test.tsx
@@ -1,36 +1,112 @@
 import faker from 'faker';
 
-import { FormModal } from '../../src';
 import { Tester } from '@mighty-justice/tester';
 
-describe('FormModal', () => {
-  it('Renders', async () => {
-    const text = faker.lorem.sentence()
-      , title = faker.lorem.sentence()
-      , props = {
-        fieldSets: [[{ field: 'text' }]],
-        model: { text },
-        title,
-      };
+import { COMPONENT_GENERATORS } from '../factories';
+import SmartBool from '@mighty-justice/smart-bool';
 
-    const tester = await new Tester(FormModal, { props }).mount();
-    expect(tester.text()).toContain(title);
-    expect(tester.text()).toContain('Text');
-    expect(tester.html()).toContain(text);
-  });
+[
+  {
+    name: 'FormModal',
+  },
+  {
+    name: 'FormDrawer',
+  },
+].forEach(({ name }) => {
+  describe(name, () => {
+    it('Renders', async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[name]
+        , exampleValue = faker.lorem.sentence()
+        , title = faker.lorem.sentence()
+        , props = {
+          ...propsFactory.build(),
+          fieldSets: [[{ field: 'exampleField' }]],
+          model: { exampleField: exampleValue },
+          title,
+        };
 
-  it('Renders children', async () => {
-    const textChildren = faker.lorem.sentence()
-      , textChildrenBefore = faker.lorem.sentence()
-      , props = {
-        children: textChildren,
-        childrenBefore: textChildrenBefore,
-        fieldSets: [],
-        title: 'Children Modal',
-      };
+      const tester = await new Tester(ComponentClass, { props }).mount();
+      expect(tester.text()).toContain(title);
+      expect(tester.text()).toContain('Example Field');
+      expect(tester.html()).toContain(exampleValue);
+    });
 
-    const tester = await new Tester(FormModal, { props }).mount();
-    expect(tester.text()).toContain(textChildren);
-    expect(tester.text()).toContain(textChildrenBefore);
+    it('Renders children', async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[name]
+        , textChildren = faker.lorem.sentence()
+        , textChildrenBefore = faker.lorem.sentence()
+        , props = {
+          ...propsFactory.build(),
+          children: textChildren,
+          childrenBefore: textChildrenBefore,
+        };
+
+      const tester = await new Tester(ComponentClass, { props }).mount();
+      expect(tester.text()).toContain(textChildren);
+      expect(tester.text()).toContain(textChildrenBefore);
+    });
+
+    it('Works with isVisible', async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[name]
+        , title = faker.lorem.sentence()
+        , isVisible = new SmartBool(false)
+        , props = {
+          ...propsFactory.build(),
+          isVisible,
+          title,
+        };
+
+      const tester = await new Tester(ComponentClass, { props }).mount({});
+
+      // Open modal using isVisible
+      expect(tester.text()).toBe(null);
+      isVisible.setTrue();
+      expect(tester.text()).toContain(title);
+
+      // Check that it auto-closes on successful submit
+      await tester.refresh();
+      await tester.submit();
+      expect(isVisible.isTrue).toBe(false);
+
+      // Re-open and test cancel button
+      isVisible.setTrue();
+      tester.click('button > span[children="Cancel"]');
+      expect(isVisible.isTrue).toBe(false);
+    });
+
+    it('Works with onSuccess and onCancel', async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[name]
+        , title = faker.lorem.sentence()
+        , onCancel = jest.fn()
+        , onSuccess = jest.fn()
+        , isVisible = new SmartBool(true)
+        , props = {
+          ...propsFactory.build(),
+          isVisible,
+          onCancel,
+          onSuccess,
+          title,
+        };
+
+      const tester = await new Tester(ComponentClass, { props }).mount();
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+
+      // Test submit button
+      onCancel.mockClear();
+      onSuccess.mockClear();
+      await tester.submit();
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+      expect(isVisible.isTrue).toBe(true);
+
+      // Test cancel button
+      onCancel.mockClear();
+      onSuccess.mockClear();
+      tester.click('button > span[children="Cancel"]');
+      expect(onCancel).toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(isVisible.isTrue).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
**Jira:** https://thatsmighty.atlassian.net/browse/MTY-1094
**Jira:** https://thatsmighty.atlassian.net/browse/MTY-1095

- Create `ISharedFormModalProps` for both components to use
- Add `isVisible` SmartBool` to `FormModal`
- Make `isVisible` optional in both modals, default to always showing
- Automatically call isVisible.setFalse on `onSuccess` and `onCancel` if they are not specified
- Default side-modal width to 600px, to minimize the number of required props needed.