### PR TITLE
Reduce code in FormDrawer and don't render hidden modals

### DIFF
--- a/src/components/FormDrawer.tsx
+++ b/src/components/FormDrawer.tsx
@@ -1,39 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
-import { omit } from 'lodash';
 import cx from 'classnames';
 
 import * as Antd from 'antd';
 
-import { formPropsDefaults } from '../propsDefaults';
-import { ISharedFormModalProps } from '../props';
-
 import Form from './Form';
+import FormModal from './FormModal';
 
 @autoBindMethods
 @observer
-class FormDrawer extends Component<ISharedFormModalProps> {
-  public static defaultProps: Partial<ISharedFormModalProps> = {
-    ...formPropsDefaults,
-  };
-
-  private onCancel () {
-    const { onCancel, isVisible } = this.props;
-    if (onCancel) { onCancel(); }
-    if (isVisible && !onCancel) { isVisible.setFalse(); }
-  }
-
-  private async onSuccess () {
-    const { onSuccess, isVisible } = this.props;
-    if (onSuccess) { await onSuccess(); }
-    if (isVisible && !onSuccess) { isVisible.setFalse(); }
-  }
-
+class FormDrawer extends FormModal {
   public render () {
-    const { className, isVisible, title, width } = this.props
-      , drawerClassName = cx('mfa-form-drawer', className || null)
-      , HANDLED_PROPS = ['title', 'isVisible', 'childrenBefore'];
+    const { className, title, width } = this.props
+      , drawerClassName = cx('mfa-form-drawer', className || null);
+
+    if (!this.isVisible) { return null; }
 
     return (
       <Antd.Drawer
@@ -44,13 +26,13 @@ class FormDrawer extends Component<ISharedFormModalProps> {
         onClose={this.onCancel}
         placement='right'
         title={title}
-        visible={isVisible ? isVisible.isTrue : true}
+        visible={true}
         width={width || '600px'}
       >
         {this.props.childrenBefore}
 
         <Form
-          {...omit(this.props, HANDLED_PROPS)}
+          {...this.formProps}
           onCancel={this.onCancel}
           onSuccess={this.onSuccess}
         />

--- a/src/components/FormModal.tsx
+++ b/src/components/FormModal.tsx
@@ -21,13 +21,23 @@ class FormModal extends Component<ISharedFormModalProps> {
     ...formPropsDefaults,
   };
 
-  private onCancel () {
+  public get isVisible () {
+    const { isVisible } = this.props;
+    return isVisible ? isVisible.isTrue : true;
+  }
+
+  public get formProps () {
+    const HANDLED_PROPS = ['title', 'isVisible', 'childrenBefore'];
+    return omit(this.props, HANDLED_PROPS);
+  }
+
+  public onCancel () {
     const { onCancel, isVisible } = this.props;
     if (onCancel) { onCancel(); }
     if (isVisible && !onCancel) { isVisible.setFalse(); }
   }
 
-  private async onSuccess () {
+  public async onSuccess () {
     const { onSuccess, isVisible } = this.props;
     if (onSuccess) { await onSuccess(); }
     if (isVisible && !onSuccess) { isVisible.setFalse(); }
@@ -56,28 +66,27 @@ class FormModal extends Component<ISharedFormModalProps> {
   }
 
   public render () {
-    const { isVisible, title, width } = this.props
-      , HANDLED_PROPS = ['title', 'isVisible', 'children', 'childrenBefore'];
+    const { title, width } = this.props;
+
+    if (!this.isVisible) { return null; }
 
     return (
       <Antd.Modal
         onCancel={this.onCancel}
         title={title}
-        visible={isVisible ? isVisible.isTrue : true}
+        visible={true}
         width={width}
         {...this.modalProps}
       >
         {this.props.childrenBefore}
 
         <Form
-          {...omit(this.props, HANDLED_PROPS)}
+          {...this.formProps}
           onCancel={this.onCancel}
           onSuccess={this.onSuccess}
           setRefFormManager={this.setRefFormManager}
           showControls={false}
         />
-
-        {this.props.children}
       </Antd.Modal>
     );
   }

--- a/test/components/FormModal.test.tsx
+++ b/test/components/FormModal.test.tsx
@@ -70,6 +70,7 @@ import SmartBool from '@mighty-justice/smart-bool';
 
       // Re-open and test cancel button
       isVisible.setTrue();
+      await tester.refresh();
       tester.click('button > span[children="Cancel"]');
       expect(isVisible.isTrue).toBe(false);
     });


### PR DESCRIPTION
These changes are required to make modals perform a bit closer to how they performed before 0.2, which is not rendering at all unless they are being shown.

Also changed FormDrawer so it inherits from FormModal and removes a ton of code.