### PR TITLE
Disable submit button on form validation errors

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -71,6 +71,10 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
+  private hasErrors = (fieldsError: any) => {
+    return Object.keys(fieldsError).some((field) => fieldsError[field])
+  }
+
   private renderControls () {
     const {
         blockSubmit,
@@ -83,6 +87,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
         loading: this.formManager.saving,
         size: 'large',
         type: 'primary',
+        disabled: this.hasErrors(this.formManager.form.getFieldsError()),
       };
 
     if (blockSubmit) {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -88,6 +88,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
         loading: this.formManager.saving,
         size: 'large',
         type: 'primary',
+        disabled: this.hasErrors(this.formManager.form.getFieldsError()),
       };
 
     if (blockSubmit) {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -71,8 +71,9 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
-  private hasErrors = (fieldsError: any) =>
-    Object.keys(fieldsError).some((field) => fieldsError[field])
+  private hasErrors (fieldsError: any) {
+    return Object.keys(fieldsError).some((field) => fieldsError[field]);
+  }
 
   private renderControls () {
     const {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -71,9 +71,9 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
-  private hasErrors = (fieldsError: any) => {
-    return Object.keys(fieldsError).some((field) => fieldsError[field])
-  }
+  private hasErrors = (fieldsError: any) => 
+    Object.keys(fieldsError).some((field) => fieldsError[field]);
+  
 
   private renderControls () {
     const {
@@ -83,11 +83,11 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
       } = this.props
       , submitProps: ButtonProps = {
         children: saveText,
+        disabled: this.hasErrors(this.formManager.form.getFieldsError()),
         htmlType: 'submit',
         loading: this.formManager.saving,
         size: 'large',
         type: 'primary',
-        disabled: this.hasErrors(this.formManager.form.getFieldsError()),
       };
 
     if (blockSubmit) {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -88,7 +88,6 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
         loading: this.formManager.saving,
         size: 'large',
         type: 'primary',
-        disabled: this.hasErrors(this.formManager.form.getFieldsError()),
       };
 
     if (blockSubmit) {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -71,9 +71,8 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     return fillInFieldSets(this.props.fieldSets);
   }
 
-  private hasErrors = (fieldsError: any) => 
-    Object.keys(fieldsError).some((field) => fieldsError[field]);
-  
+  private hasErrors = (fieldsError: any) =>
+    Object.keys(fieldsError).some((field) => fieldsError[field])
 
   private renderControls () {
     const {

--- a/test/components/FormCard.test.tsx
+++ b/test/components/FormCard.test.tsx
@@ -28,6 +28,7 @@ describe('FormCard', () => {
     tester.submit();
     await tester.sleep();
     expect(onSave).toHaveBeenCalledWith({ text: newText });
+    expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
   });
 
   it('Maps backend errors to fields on form', async () => {
@@ -64,8 +65,30 @@ describe('FormCard', () => {
     const antErrorCall = (Antd.notification.error as any).calls.mostRecent();
     expect(JSON.stringify(antErrorCall)).toContain(otherError);
 
-    //expect(tester.find('button[type="submit"]')).toHaveProperty('disabled', false);
-    //expect(disabled).toBe(true);
-    expect(tester.find('.ant-btn-primary[disabled]').length).toBe(1);
+    // Expect submit button to be disabled due to error.
+    expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(1);
+  });
+
+  // Tests whether submit button correctly enables and disables.
+  it('Submit button disables after error raised', async () => {
+    const name = faker.lorem.sentence()
+    , onSave = jest.fn()
+    , props = {
+      fieldSets: [[{ field: 'name', required: true }]],
+      model: { name },
+      onSave,
+      title: 'Information',
+    };
+
+    const tester = await new Tester(FormCard, { props }).mount();
+    expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
+
+    tester.changeInput('input', null);
+    tester.click(tester.find('.ant-btn-primary'));
+    expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(1);
+
+    tester.changeInput('input', name);
+    tester.click(tester.find('.ant-btn-primary'));
+    expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
   });
 });

--- a/test/components/FormCard.test.tsx
+++ b/test/components/FormCard.test.tsx
@@ -63,5 +63,9 @@ describe('FormCard', () => {
     expect(Antd.notification.error).toHaveBeenCalled();
     const antErrorCall = (Antd.notification.error as any).calls.mostRecent();
     expect(JSON.stringify(antErrorCall)).toContain(otherError);
+
+    //expect(tester.find('button[type="submit"]')).toHaveProperty('disabled', false);
+    //expect(disabled).toBe(true);
+    expect(tester.find('.ant-btn-primary[disabled]').length).toBe(1);
   });
 });


### PR DESCRIPTION
Even though the form modal won't submit, the save button should be disabled if there is a custom validation error. 

JIRA: https://thatsmighty.atlassian.net/secure/RapidBoard.jspa?rapidView=31&projectKey=MTY&modal=detail&selectedIssue=MTY-470

Current: 

![formbutton](https://user-images.githubusercontent.com/29324143/58586273-afb9c180-8228-11e9-80e5-cf356961ce38.gif)
