### PR TITLE
Add descriptive error messages for 403 forbidden

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -46,6 +46,11 @@ interface IFormWrappedInstance {
   };
 }
 
+export const ERROR_WITH_DESCRIPTION = [
+  httpStatus.BAD_REQUEST,
+  httpStatus.FORBIDDEN,
+];
+
 export const toastError = {
   description: '',
   duration: null,
@@ -208,8 +213,7 @@ class FormManager {
     response. If so, we will try to assign those validation errors to fields, and if that fails
     we will display them in toast notifications.
     */
-    const status = get(error, 'response.status') as undefined | number
-      , describeErrors = (status === httpStatus.BAD_REQUEST || status === httpStatus.FORBIDDEN);
+    const status = get(error, 'response.status') as undefined | number;
     let backendErrors: IBackendValidation = { foundOnForm: {}, errorMessages: [] };
 
     function logError () {
@@ -225,14 +229,14 @@ class FormManager {
     }
 
     // Errors like 500 and 403 Forbidden should be as descriptive as possible
-    if (status && !describeErrors) {
+    if (status && !ERROR_WITH_DESCRIPTION.includes(status)) {
       const statusMessage = httpStatus.getStatusText(status);
       backendErrors.errorMessages.push({ field: status.toString(), message: statusMessage });
       logError();
     }
 
     // Bad request errors are mapped to fields when possible
-    if (describeErrors) {
+    if (status && ERROR_WITH_DESCRIPTION.includes(status)) {
       const { foundOnForm, errorMessages } = backendValidation(this.formFieldNames, error.response.data);
       backendErrors.errorMessages = [...backendErrors.errorMessages, ...errorMessages];
       backendErrors.foundOnForm = {...backendErrors.foundOnForm, ...foundOnForm };

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -208,7 +208,8 @@ class FormManager {
     response. If so, we will try to assign those validation errors to fields, and if that fails
     we will display them in toast notifications.
     */
-    const status = get(error, 'response.status') as undefined | number;
+    const status = get(error, 'response.status') as undefined | number
+      , describeErrors = (status === httpStatus.BAD_REQUEST || status === httpStatus.FORBIDDEN);
     let backendErrors: IBackendValidation = { foundOnForm: {}, errorMessages: [] };
 
     function logError () {
@@ -224,14 +225,14 @@ class FormManager {
     }
 
     // Errors like 500 and 403 Forbidden should be as descriptive as possible
-    if (status && status !== httpStatus.BAD_REQUEST) {
+    if (status && !describeErrors) {
       const statusMessage = httpStatus.getStatusText(status);
       backendErrors.errorMessages.push({ field: status.toString(), message: statusMessage });
       logError();
     }
 
     // Bad request errors are mapped to fields when possible
-    if (status === httpStatus.BAD_REQUEST) {
+    if (describeErrors) {
       const { foundOnForm, errorMessages } = backendValidation(this.formFieldNames, error.response.data);
       backendErrors.errorMessages = [...backendErrors.errorMessages, ...errorMessages];
       backendErrors.foundOnForm = {...backendErrors.foundOnForm, ...foundOnForm };

--- a/test/utilities/FormManager.test.tsx
+++ b/test/utilities/FormManager.test.tsx
@@ -1,15 +1,10 @@
 import faker from 'faker';
-import httpStatus from 'http-status-codes';
 import * as Antd from 'antd';
 
+import { ERROR_WITH_DESCRIPTION } from '../../src/utilities/FormManager';
 import { Tester } from '@mighty-justice/tester';
 
 import { Form, FormCard, IFieldSetPartial } from '../../src';
-
-const ERROR_TYPES = [
-  httpStatus.BAD_REQUEST,
-  httpStatus.FORBIDDEN,
-];
 
 async function getFormManager (fieldSets: IFieldSetPartial[], model = {}) {
   const props = {
@@ -87,7 +82,7 @@ describe('FormManager', () => {
     });
   });
 
-  ERROR_TYPES.forEach(errorType => {
+  ERROR_WITH_DESCRIPTION.forEach(errorType => {
     it(`Shows descriptive error messages for error type ${errorType.toString()}`, async () => {
       const fieldSets = [[
           { field: 'field_1' },


### PR DESCRIPTION
**JIRA**: https://thatsmighty.atlassian.net/secure/RapidBoard.jspa?rapidView=31&projectKey=MTY&modal=detail&selectedIssue=MTY-1149&assignee=karen

Github: https://github.com/mighty-justice/fields-ant/issues/189
Now: httpStatus.BAD_REQUEST is processed by FormManager and the useful messages presented to the user. 

These should also be presented to users, just like 400 errors.

The 'fix' . is probably just modifying the if statement to include both 400 and 403, but a test should be added for the use-case in the Github issue.