### PR TITLE
Bugfix: submit disabled on forms with nested objects

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -46,6 +46,11 @@ interface IFormWrappedInstance {
   };
 }
 
+export const ERROR_WITH_DESCRIPTION = [
+  httpStatus.BAD_REQUEST,
+  httpStatus.FORBIDDEN,
+];
+
 export const toastError = {
   description: '',
   duration: null,
@@ -208,8 +213,7 @@ class FormManager {
     response. If so, we will try to assign those validation errors to fields, and if that fails
     we will display them in toast notifications.
     */
-    const status = get(error, 'response.status') as undefined | number
-      , describeErrors = (status === httpStatus.BAD_REQUEST || status === httpStatus.FORBIDDEN);
+    const status = get(error, 'response.status') as undefined | number;
     let backendErrors: IBackendValidation = { foundOnForm: {}, errorMessages: [] };
 
     function logError () {
@@ -225,14 +229,14 @@ class FormManager {
     }
 
     // Errors like 500 and 403 Forbidden should be as descriptive as possible
-    if (status && !describeErrors) {
+    if (status && !ERROR_WITH_DESCRIPTION.includes(status)) {
       const statusMessage = httpStatus.getStatusText(status);
       backendErrors.errorMessages.push({ field: status.toString(), message: statusMessage });
       logError();
     }
 
     // Bad request errors are mapped to fields when possible
-    if (describeErrors) {
+    if (status && ERROR_WITH_DESCRIPTION.includes(status)) {
       const { foundOnForm, errorMessages } = backendValidation(this.formFieldNames, error.response.data);
       backendErrors.errorMessages = [...backendErrors.errorMessages, ...errorMessages];
       backendErrors.foundOnForm = {...backendErrors.foundOnForm, ...foundOnForm };

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -88,7 +88,7 @@ class FormManager {
   }
 
   public get submitButtonDisabled () {
-    return this.hasErrors(this.form.getFieldsError());
+    return this.hasErrors();
   }
 
   public getDefaultValue (fieldConfig: IFieldConfig) {
@@ -202,8 +202,9 @@ class FormManager {
     });
   }
 
-  private hasErrors (fieldsError: any) {
-    return Object.keys(fieldsError).some((field) => fieldsError[field]);
+  private hasErrors () {
+    const fieldsError = flattenObject<{ [key: string]: any }, { [key: string]: any }>(this.form.getFieldsError());
+    return Object.keys((fieldsError)).some((field) => fieldsError[field]);
   }
 
   private handleRequestError (error: Error & { response?: any }) {

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -208,7 +208,8 @@ class FormManager {
     response. If so, we will try to assign those validation errors to fields, and if that fails
     we will display them in toast notifications.
     */
-    const status = get(error, 'response.status') as undefined | number;
+    const status = get(error, 'response.status') as undefined | number
+      , describeErrors = (status === httpStatus.BAD_REQUEST || status === httpStatus.FORBIDDEN);
     let backendErrors: IBackendValidation = { foundOnForm: {}, errorMessages: [] };
 
     function logError () {
@@ -224,14 +225,14 @@ class FormManager {
     }
 
     // Errors like 500 and 403 Forbidden should be as descriptive as possible
-    if (status && status !== httpStatus.BAD_REQUEST) {
+    if (status && !describeErrors) {
       const statusMessage = httpStatus.getStatusText(status);
       backendErrors.errorMessages.push({ field: status.toString(), message: statusMessage });
       logError();
     }
 
     // Bad request errors are mapped to fields when possible
-    if (status === httpStatus.BAD_REQUEST) {
+    if (describeErrors) {
       const { foundOnForm, errorMessages } = backendValidation(this.formFieldNames, error.response.data);
       backendErrors.errorMessages = [...backendErrors.errorMessages, ...errorMessages];
       backendErrors.foundOnForm = {...backendErrors.foundOnForm, ...foundOnForm };

--- a/test/features/submitButtonDisabled.test.ts
+++ b/test/features/submitButtonDisabled.test.ts
@@ -33,5 +33,19 @@ describe('submitButtonDisabled', () => {
       tester.click(tester.find('.ant-btn-primary'));
       expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
     });
+
+    it(`Submit button correctly disables in nested forms on ${componentName}`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName]
+        , props = propsFactory.build({
+            fieldSets: [[{ field: 'plaintiff.name'}]],
+        });
+
+      const tester = await new Tester(ComponentClass, { props }).mount();
+      expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
+
+      tester.changeInput('input', 'Name');
+      tester.click(tester.find('.ant-btn-primary'));
+      expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
+    });
   });
 });

--- a/test/utilities/FormManager.test.tsx
+++ b/test/utilities/FormManager.test.tsx
@@ -1,15 +1,10 @@
 import faker from 'faker';
-import httpStatus from 'http-status-codes';
 import * as Antd from 'antd';
 
+import { ERROR_WITH_DESCRIPTION } from '../../src/utilities/FormManager';
 import { Tester } from '@mighty-justice/tester';
 
 import { Form, FormCard, IFieldSetPartial } from '../../src';
-
-const ERROR_TYPES = [
-  httpStatus.BAD_REQUEST,
-  httpStatus.FORBIDDEN,
-];
 
 async function getFormManager (fieldSets: IFieldSetPartial[], model = {}) {
   const props = {
@@ -87,7 +82,7 @@ describe('FormManager', () => {
     });
   });
 
-  ERROR_TYPES.forEach(errorType => {
+  ERROR_WITH_DESCRIPTION.forEach(errorType => {
     it(`Shows descriptive error messages for error type ${errorType.toString()}`, async () => {
       const fieldSets = [[
           { field: 'field_1' },


### PR DESCRIPTION
JIRA: https://thatsmighty.atlassian.net/browse/MTY-1223

The submit button was disabling on forms with nested objects.

BEFORE:
![bug-before](https://user-images.githubusercontent.com/29324143/59055963-1a8c7d80-8865-11e9-9591-5e588e48bf73.gif)


AFTER:
![bug-after](https://user-images.githubusercontent.com/29324143/59055904-f16bed00-8864-11e9-9744-c2db56773ee5.gif)
