### PR TITLE
Bugfix: Submit is disabled when editing forms with nested objects

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -199,7 +199,7 @@ class FormManager {
 
   private hasErrors () {
     const fieldsError = flattenObject<{ [key: string]: any }, { [key: string]: any }>(this.form.getFieldsError());
-    return Object.keys((fieldsError)).some((field) => fieldsError[field]);
+    return Object.keys(fieldsError).some(field => fieldsError[field]);
   }
 
   private handleRequestError (error: Error & { response?: any }) {

--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -83,7 +83,7 @@ class FormManager {
   }
 
   public get submitButtonDisabled () {
-    return this.hasErrors(this.form.getFieldsError());
+    return this.hasErrors();
   }
 
   public getDefaultValue (fieldConfig: IFieldConfig) {
@@ -197,8 +197,9 @@ class FormManager {
     });
   }
 
-  private hasErrors (fieldsError: any) {
-    return Object.keys(fieldsError).some((field) => fieldsError[field]);
+  private hasErrors () {
+    const fieldsError = flattenObject<{ [key: string]: any }, { [key: string]: any }>(this.form.getFieldsError());
+    return Object.keys((fieldsError)).some((field) => fieldsError[field]);
   }
 
   private handleRequestError (error: Error & { response?: any }) {

--- a/test/features/submitButtonDisabled.test.ts
+++ b/test/features/submitButtonDisabled.test.ts
@@ -33,5 +33,19 @@ describe('submitButtonDisabled', () => {
       tester.click(tester.find('.ant-btn-primary'));
       expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
     });
+
+    it(`Submit button correctly disables in nested forms on ${componentName}`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName]
+        , props = propsFactory.build({
+            fieldSets: [[{ field: 'plaintiff.name'}]],
+        });
+
+      const tester = await new Tester(ComponentClass, { props }).mount();
+      expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
+
+      tester.changeInput('input', 'Name');
+      tester.click(tester.find('.ant-btn-primary'));
+      expect(tester.find('.ant-btn-primary[disabled=true]').length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
JIRA: https://thatsmighty.atlassian.net/browse/MTY-1223

BEFORE:
![bug-before](https://user-images.githubusercontent.com/29324143/59056261-cf269f00-8865-11e9-87ec-56df146d98fb.gif)


AFTER:

![bug-after](https://user-images.githubusercontent.com/29324143/59056265-d188f900-8865-11e9-866f-84baf2e70088.gif)
