### PR TITLE
Breaking change: ObjectSearchCreate takes full endpoint URL and handles errors

### DIFF
--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -133,6 +133,9 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     try {
       const response = await getEndpoint(`${endpoint}${toKey(params)}`);
       this.options = get(response, 'results', []);
+    } catch (error) {
+      // tslint:disable-next-line no-console
+      console.error(error);
     } finally {
       this.isLoading.setFalse();
     }

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -130,9 +130,12 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     this.search = value;
     this.isLoading.setTrue();
     this.updateValueCaches();
-    const response = await getEndpoint(`/${endpoint}/${toKey(params)}`);
-    this.options = response.results;
-    this.isLoading.setFalse();
+    try {
+      const response = await getEndpoint(`${endpoint}${toKey(params)}`);
+      this.options = get(response, 'results', []);
+    } finally {
+      this.isLoading.setFalse();
+    }
   }
 
   private renderOptionAdd () {

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -137,8 +137,10 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
     // istanbul ignore next
     } catch (error) {
-      // tslint:disable-next-line no-console
-      console.error(error); // istanbul ignore
+      // tslint:disable no-console
+      // istanbul ignore next
+      console.error(error);
+      // tslint:enable no-console
 
     } finally {
       this.isLoading.setFalse();

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -138,7 +138,7 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     // istanbul ignore next
     } catch (error) {
       // tslint:disable-next-line no-console
-      console.error(error);
+      console.error(error); // istanbul ignore
 
     } finally {
       this.isLoading.setFalse();

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -130,12 +130,16 @@ class ObjectSearch extends Component<IObjectSearchProps> {
     this.search = value;
     this.isLoading.setTrue();
     this.updateValueCaches();
+
     try {
       const response = await getEndpoint(`${endpoint}${toKey(params)}`);
       this.options = get(response, 'results', []);
+
+    // istanbul ignore next
     } catch (error) {
       // tslint:disable-next-line no-console
       console.error(error);
+
     } finally {
       this.isLoading.setFalse();
     }

--- a/test/types/objectSearch.test.ts
+++ b/test/types/objectSearch.test.ts
@@ -14,7 +14,7 @@ function fakeLawFirm () {
 
 function getFormDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
-    , endpoint = 'legal-organizations'
+    , endpoint = '/legal-organizations/'
     , type = overrides.type || 'objectSearch'
     , fieldConfig = fillInFieldConfig({
       editProps: { debounceWait: 0 },
@@ -47,7 +47,7 @@ function getFormDefaults (overrides?: any) {
 
 function getComponentDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
-    , endpoint = 'legal-organizations'
+    , endpoint = '/legal-organizations/'
     , type = overrides.type || 'objectSearch'
     , fieldConfig = fillInFieldConfig({ field, type, endpoint, ...overrides.fieldConfig })
     , props = { id: field, fieldConfig, debounceWait: 0 }
@@ -98,10 +98,10 @@ describe('objectSearch', () => {
   it('Properly caches and displays options', async () => {
     const { field, searchTerm, result, props, endpoint } = getComponentDefaults({})
       , tester = (await new Tester(ObjectSearch, { props }).mount() as any)
-      , newEndpoint = `${endpoint}-2`
+      , newEndpoint = `${endpoint}2/`
       ;
 
-    tester.endpoints[`/${newEndpoint}/`] = { results: [result] };
+    tester.endpoints[newEndpoint] = { results: [result] };
 
     expect(tester.getEndpoint.mock.calls.length).toBe(0);
 

--- a/test/types/objectSearchCreate.test.ts
+++ b/test/types/objectSearchCreate.test.ts
@@ -17,7 +17,7 @@ function fakeLawFirm () {
 function getDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
     , editProps = { debounceWait: 0 }
-    , endpoint = overrides.endpoint || 'legal-organizations'
+    , endpoint = overrides.endpoint || '/legal-organizations/'
     , type = overrides.type || 'objectSearchCreate'
     , createFields = overrides.createFields || [{ field: 'name', required: true }, { field: 'amount_owed' }]
     , fieldConfig = { editProps, field, type, endpoint, createFields, ...overrides.fieldConfig }


### PR DESCRIPTION
This change is actually for a side-project of mine that returns a 400 on empty searches. Right now that crashes ObjectSearch.

This will require very minor changes to places that use objectSearchCreate to re-add the / at the beginning and end.