### PR TITLE
Fix date autofill

### DIFF
--- a/src/inputs/Date.tsx
+++ b/src/inputs/Date.tsx
@@ -73,13 +73,13 @@ class Date extends Component<IInputProps> {
   private onChange (field: IField, inputValue: string) {
     const regexNumbers = /[^0-9]+/
       , trimmedValue = inputValue.trim()
-      , cleanedValue = regexNumbers.test(trimmedValue) ? '' : trimmedValue
+      , cleanedValue = regexNumbers.test(trimmedValue) ? 'invalid' : trimmedValue
       , filledInValue = (field === 'year')
         ? inferCentury(cleanedValue)
         : cleanedValue ? cleanedValue.padStart(2, '0') : ''
       , valueObject = { ...this.valueObject, [field]: filledInValue }
       , { year, day, month } = valueObject
-      , value = (year && month && day) ? [year, month, day].join('-') : ''
+      , value = (year || month || day) ? [year, month, day].join('-') : ''
       ;
 
     this.injected.onChange(value);

--- a/src/inputs/Date.tsx
+++ b/src/inputs/Date.tsx
@@ -76,10 +76,10 @@ class Date extends Component<IInputProps> {
       , cleanedValue = regexNumbers.test(trimmedValue) ? '' : trimmedValue
       , filledInValue = (field === 'year')
         ? inferCentury(cleanedValue)
-        : cleanedValue.padStart(2, '0')
+        : cleanedValue ? cleanedValue.padStart(2, '0') : ''
       , valueObject = { ...this.valueObject, [field]: filledInValue }
       , { year, day, month } = valueObject
-      , value = [year, month, day].join('-')
+      , value = (year && month && day) ? [year, month, day].join('-') : ''
       ;
 
     this.injected.onChange(value);

--- a/test/types/date.test.ts
+++ b/test/types/date.test.ts
@@ -86,4 +86,26 @@ describe('date', () => {
     expect(await checkInferYear('50')).toBe('1950');
     expect(await checkInferYear('98')).toBe('1998');
   });
+
+  it('Changes input before submission', async () => {
+    const { fieldConfigFactory } = TYPE_GENERATORS.date
+      , fieldConfig = fieldConfigFactory.build()
+      , fieldSets = [[fieldConfig]]
+      , onSave = jest.fn()
+      , props = { fieldSets, onSave, required: false }
+      ;
+
+    const tester = await new Tester(FormCard, { props }).mount();
+
+    tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '01');
+    tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '01');
+    tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '2019');
+
+    tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '');
+    tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '');
+    tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '');
+    await tester.submit();
+
+    expect(!!onSave.mock.calls.length).toBe(true);
+    });
 });

--- a/test/types/date.test.ts
+++ b/test/types/date.test.ts
@@ -76,7 +76,7 @@ describe('date', () => {
     expect(await isInputsValid('11', '22', '1989a')).toBe(false);
     expect(await isInputsValid('11', '22', '----')).toBe(false);
     expect(await isInputsValid('11', '22', '1989-')).toBe(false);
-    expect(await isInputsValid('', '', '')).toBe(false);
+    expect(await isInputsValid('', '', '')).toBe(true);
     expect(await isInputsValid('D', 'o', 'g')).toBe(false);
   });
 
@@ -107,5 +107,5 @@ describe('date', () => {
     await tester.submit();
 
     expect(!!onSave.mock.calls.length).toBe(true);
-    });
+  });
 });


### PR DESCRIPTION
**JIRA**: https://thatsmighty.atlassian.net/browse/MTY-1313

Previously the date component was autofilling to 00-00 when deleting the month and date, which would raise form validation errors when the date was filled in and then deleted.