### PR TITLE
Allow <Card> component to receive a custom className

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import cx from 'classnames';
 
 import * as Antd from 'antd';
 
@@ -22,11 +23,16 @@ class Card extends Component<ICardProps> {
   }
 
   public render () {
-    const { title, renderTopRight, isLoading, model } = this.props
+    const { className, title, renderTopRight, isLoading, model } = this.props
       , filteredFieldSets = filterFieldSets(this.fieldSets, { model, writeOnly: true });
 
     return (
-      <Antd.Card title={title} extra={renderTopRight && renderTopRight()} loading={isLoading}>
+      <Antd.Card
+        className={cx('mfa-card', className)}
+        extra={renderTopRight && renderTopRight()}
+        loading={isLoading}
+        title={title}
+      >
         {filteredFieldSets.map((fieldSet, idx) => (
           <CardFieldSet
             fieldSet={fieldSet}


### PR DESCRIPTION
Even if the documentation mentions it, specifying a `className` in the `<Card />` `props` doesn't apply it to the `<Card />`.

**PROOF OF DOCUMENTATION:**
<img width="781" alt="Screen Shot 2019-08-18 at 9 20 03 PM" src="https://user-images.githubusercontent.com/1119991/63233401-f9012800-c1fd-11e9-8375-6ed056b121eb.png">

**Testing the changes:** 
<img width="924" alt="Screen Shot 2019-08-18 at 9 17 40 PM" src="https://user-images.githubusercontent.com/1119991/63233404-fbfc1880-c1fd-11e9-808d-6c7875f03608.png">


