### PR TITLE
Support multiselect in ObjectSearch

### DIFF
--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -19,6 +19,7 @@ import {
   IInjected,
   IInputProps,
 } from '../';
+import { IValue } from '../props';
 
 export interface IObjectSearchProps {
   addNewContent?: React.ReactNode;
@@ -27,6 +28,7 @@ export interface IObjectSearchProps {
   loadingIcon?: React.ReactNode;
   noSearchContent?: React.ReactNode;
   onAddNew?: (search: string) => void;
+  onChange: (value: IValue) => void;
   searchIcon?: React.ReactNode;
   selectProps: SelectProps;
 }

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -229,9 +229,8 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
     // Select from search
     if (this.isMultiSelect) {
-      const foundOptions = this.options.filter(option => (
-        selectedOption.map((_selectedOption: any) => _selectedOption.key).includes(option.id)
-      ));
+      const selectedOptionIds = selectedOption.map((_selectedOption: any) => _selectedOption.key)
+        , foundOptions = this.options.filter(option => selectedOptionIds.includes(option.id));
       onChange(toJS(foundOptions));
     } else {
       const foundOption = this.options.find(option => option.id === selectedOption.key);

--- a/src/inputs/ObjectSearch.tsx
+++ b/src/inputs/ObjectSearch.tsx
@@ -229,9 +229,9 @@ class ObjectSearch extends Component<IObjectSearchProps> {
 
     // Select from search
     if (this.isMultiSelect) {
-      const foundOptions = this.options.filter(option =>
-        selectedOption.map((selectedOption: any) => selectedOption.key).includes(option.id)
-      );
+      const foundOptions = this.options.filter(option => (
+        selectedOption.map((_selectedOption: any) => _selectedOption.key).includes(option.id)
+      ));
       onChange(toJS(foundOptions));
     } else {
       const foundOption = this.options.find(option => option.id === selectedOption.key);
@@ -260,22 +260,22 @@ class ObjectSearch extends Component<IObjectSearchProps> {
       if (!value) { return { value: undefined }; }
 
       return {
-        value: value.map((value: any) => ({
-          key: value.id,
-          label: renderSelected(value)
-        }))
-      };
-    } else {
-      const valueId = get(value, 'id');
-      if (!valueId) { return { value: undefined }; }
-
-      return {
-        value: {
-          key: valueId,
-          label: renderSelected(value),
-        },
+        value: value.map((_value: any) => ({
+          key: _value.id,
+          label: renderSelected(_value),
+        })),
       };
     }
+
+    const valueId = get(value, 'id');
+    if (!valueId) { return { value: undefined }; }
+
+    return {
+      value: {
+        key: valueId,
+        label: renderSelected(value),
+      },
+    };
   }
 
   public render () {

--- a/stories/9_misc.stories.tsx
+++ b/stories/9_misc.stories.tsx
@@ -11,6 +11,7 @@ import { FormCard, IFieldConfigObjectSearchCreate, IFieldConfigPartial } from '.
 import {
   fakeField,
   formCardPropsFactory,
+  objectSearchFactory,
   objectSearchCreateFactory,
   TYPE_GENERATORS,
 } from '../test/factories';
@@ -155,6 +156,27 @@ storiesOf('Misc.', module)
         }]}
       />
       <Marked md={docObjectSearchCreate} />
+    </>
+  ))
+  .add('objectSearch Multiselect', () => (
+    <>
+      <Marked md={`# { type: 'objectSearch' }`} />
+      <FormCard
+        {...formCardPropsFactory.build()}
+        fieldSets={[{
+          fields: [
+            {
+              ...objectSearchFactory.build() as IFieldConfigObjectSearchCreate,
+              colProps: { sm: 24, lg: 12 },
+              editProps: {
+                selectProps: { mode: 'multiple' },
+              },
+            },
+          ],
+          legend: 'Legend Text',
+          rowProps: { gutter: 16 },
+        }]}
+      />
     </>
   ))
   ;

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -130,6 +130,12 @@ export const objectSearchCreateFactory = fieldFactoryForType('objectSearchCreate
     endpoint: '/endpoint/',
   });
 
+export const organizationResultFactory = new Factory()
+  .attrs({
+    id: faker.random.uuid,
+    name: faker.company.companyName,
+  })
+
 /*
  *   FIELD SET FACTORY
  * = = = = = = = = = = = = = =

--- a/test/types/objectSearch.test.ts
+++ b/test/types/objectSearch.test.ts
@@ -3,14 +3,8 @@ import faker from 'faker';
 import { Tester } from '@mighty-justice/tester';
 
 import { fillInFieldConfig, FormCard } from '../../src';
+import { organizationResultFactory } from '../factories';
 import ObjectSearch from '../../src/inputs/ObjectSearch';
-
-function fakeLawFirm () {
-  return {
-    id: faker.random.uuid(),
-    name: faker.company.companyName(),
-  };
-}
 
 function getFormDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
@@ -30,7 +24,7 @@ function getFormDefaults (overrides?: any) {
     ;
 
   return {
-    results: Array(3).fill(null).map(() => fakeLawFirm()),
+    results: organizationResultFactory.buildList(3),
     searchTerm: faker.lorem.sentence(),
 
     endpoint,
@@ -54,7 +48,7 @@ function getComponentDefaults (overrides?: any) {
     ;
 
   return {
-    results: Array(3).fill(null).map(() => fakeLawFirm()),
+    results: organizationResultFactory.buildList(3),
     searchTerm: faker.lorem.sentence(),
 
     endpoint,
@@ -81,7 +75,7 @@ export async function objectSearchFor (tester: any, field: string, results: any,
 
 describe('objectSearch', () => {
   it('Clears existing', async () => {
-    const model = { law_firm: fakeLawFirm() }
+    const model = { law_firm: organizationResultFactory.build() }
       , { props } = getFormDefaults({ model })
       , tester = (await new Tester(FormCard, { props }).mount())
       , CLEAR_BUTTON = '.ant-select-selection__clear'

--- a/test/types/objectSearch.test.ts
+++ b/test/types/objectSearch.test.ts
@@ -8,7 +8,7 @@ import ObjectSearch from '../../src/inputs/ObjectSearch';
 function fakeLawFirm () {
   return {
     id: faker.random.uuid(),
-      name: faker.company.companyName(),
+    name: faker.company.companyName(),
   };
 }
 
@@ -30,7 +30,7 @@ function getFormDefaults (overrides?: any) {
     ;
 
   return {
-    result: fakeLawFirm(),
+    results: Array(3).fill(null).map(() => fakeLawFirm()),
     searchTerm: faker.lorem.sentence(),
 
     endpoint,
@@ -54,7 +54,7 @@ function getComponentDefaults (overrides?: any) {
     ;
 
   return {
-    result: fakeLawFirm(),
+    results: Array(3).fill(null).map(() => fakeLawFirm()),
     searchTerm: faker.lorem.sentence(),
 
     endpoint,
@@ -68,8 +68,8 @@ function getComponentDefaults (overrides?: any) {
   };
 }
 
-export async function objectSearchFor (tester: any, field: string, result: any, searchTerm: string) {
-  tester.endpoints['/legal-organizations/'] = { results: [result] };
+export async function objectSearchFor (tester: any, field: string, results: any, searchTerm: string) {
+  tester.endpoints['/legal-organizations/'] = { results };
 
   // Change input without blurring
   const component = tester.find(`input#${field}`).first();
@@ -96,17 +96,17 @@ describe('objectSearch', () => {
   });
 
   it('Properly caches and displays options', async () => {
-    const { field, searchTerm, result, props, endpoint } = getComponentDefaults({})
+    const { field, searchTerm, results, props, endpoint } = getComponentDefaults({})
       , tester = (await new Tester(ObjectSearch, { props }).mount() as any)
       , newEndpoint = `${endpoint}2/`
       ;
 
-    tester.endpoints[newEndpoint] = { results: [result] };
+    tester.endpoints[newEndpoint] = { results };
 
     expect(tester.getEndpoint.mock.calls.length).toBe(0);
 
     // First search
-    await objectSearchFor(tester, field, result, searchTerm);
+    await objectSearchFor(tester, field, results, searchTerm);
     expect(tester.getEndpoint.mock.calls.length).toBe(1);
 
     // Re-focus but no new props
@@ -117,5 +117,20 @@ describe('objectSearch', () => {
     props.fieldConfig.endpoint = newEndpoint;
     tester.instance.onFocus();
     expect(tester.getEndpoint.mock.calls.length).toBe(2);
+  });
+
+  it('Can select multiple options', async () => {
+    const overrides = { fieldConfig: { editProps: { selectProps: { mode: 'multiple' } } } }
+      , { field, searchTerm, results, props } = getFormDefaults(overrides)
+      , tester = (await new Tester(FormCard, { props }).mount())
+      ;
+
+    await objectSearchFor(tester, field, results, searchTerm);
+    tester.click(tester.find('.ant-select-dropdown-menu-item').first());
+    tester.click(tester.find('.ant-select-dropdown-menu-item').last());
+
+    expect(tester.text()).toContain(results[0].name);
+    expect(tester.text()).not.toContain(results[1].name);
+    expect(tester.text()).toContain(results[2].name);
   });
 });

--- a/test/types/objectSearchCreate.test.ts
+++ b/test/types/objectSearchCreate.test.ts
@@ -3,16 +3,9 @@ import faker from 'faker';
 import { Tester } from '@mighty-justice/tester';
 
 import { FormCard } from '../../src';
-import { fakeTextShort } from '../factories';
+import { fakeTextShort, organizationResultFactory } from '../factories';
 
 import { objectSearchFor } from './objectSearch.test';
-
-function fakeLawFirm () {
-  return {
-    id: faker.random.uuid(),
-    name: faker.company.companyName(),
-  };
-}
 
 function getDefaults (overrides?: any) {
   const field = overrides.field || 'law_firm'
@@ -30,7 +23,7 @@ function getDefaults (overrides?: any) {
   return {
     expectedLabel: 'Law Firm',
     fakeOwed: faker.finance.amount(),
-    results: Array(3).fill(null).map(() => fakeLawFirm()),
+    results: organizationResultFactory.buildList(3),
     searchTerm: faker.lorem.sentence(),
 
     createFields,
@@ -108,7 +101,7 @@ describe('objectSearchCreate', () => {
 
   it('Clears existing record on add new', async () => {
     const { field, onSave, searchTerm, results, props } = getDefaults({
-        model: { law_firm: fakeLawFirm() },
+        model: { law_firm: organizationResultFactory.build() },
       })
       , tester = await getTester(props)
       ;


### PR DESCRIPTION
- adds support for multiselect in ObjectSearch.
- also adds `onChange` to `IObjectSearchProps` to fix https://github.com/mighty-justice/fields-ant/issues/240

![object-search-multiselect](https://user-images.githubusercontent.com/1393482/65273409-17a15a00-daef-11e9-82dc-ddbffcf0cf0d.gif)
