### PR TITLE
Fix to pass isOptionDisabled in ObjectSearchCreate edit props

### DIFF
--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -14,6 +14,7 @@ import {
   CX_PREFIX_SEARCH_CREATE,
   FormManager,
   IAntFormField,
+  IEndpointOption,
   IFieldConfig,
   IFieldConfigObjectSearchCreate,
   IInjected,
@@ -42,7 +43,7 @@ export interface IObjectSearchCreateProps {
   fieldDecorator: <T>(component: T) => T;
   formManager: FormManager;
   formModel: IModel;
-  isOptionDisabled?: (option: any) => boolean;
+  isOptionDisabled?: (option: IEndpointOption) => boolean;
   loadingIcon?: React.ReactNode;
   noSearchContent?: React.ReactNode;
   onAddNewToggle?: (isAddingNew: boolean) => void;

--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -42,6 +42,7 @@ export interface IObjectSearchCreateProps {
   fieldDecorator: <T>(component: T) => T;
   formManager: FormManager;
   formModel: IModel;
+  isOptionDisabled?: (option: any) => boolean;
   loadingIcon?: React.ReactNode;
   noSearchContent?: React.ReactNode;
   onAddNewToggle?: (isAddingNew: boolean) => void;
@@ -68,6 +69,7 @@ class ObjectSearchCreate extends Component<IObjectSearchCreateProps> {
       'addNewContent',
       'debounceWait',
       'fieldConfig',
+      'isOptionDisabled',
       'loadingIcon',
       'noSearchContent',
       'searchIcon',


### PR DESCRIPTION
Follow up to #241 .

To be passed as an edit prop, the param `isOptionDisabled` must be added to the OSC interface and specifically picked from `editProps`.