### PR TITLE
Add trim whitespace component and apply to url and email fields

### DIFF
--- a/src/inputs/TrimWhitespaceInput.tsx
+++ b/src/inputs/TrimWhitespaceInput.tsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
-import { Input } from 'antd';
-import autoBindMethods from 'class-autobind-decorator';
 import { observer } from 'mobx-react';
 import { observable } from 'mobx';
+import autoBindMethods from 'class-autobind-decorator';
+
+import { Input } from 'antd';
+
 import { IAntFormField, IInjected, IInputProps } from '../interfaces';
 
 @autoBindMethods

--- a/src/inputs/TrimWhitespaceInput.tsx
+++ b/src/inputs/TrimWhitespaceInput.tsx
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import { Input } from 'antd';
+import autoBindMethods from 'class-autobind-decorator';
+import { observer } from 'mobx-react';
+import { observable } from 'mobx';
+import { IAntFormField, IInjected, IInputProps } from '../interfaces';
+
+@autoBindMethods
+@observer
+class TrimWhitespaceInput extends Component<{}> {
+  @observable private value = '';
+
+  private get injected () {
+    return this.props as IInjected & IInputProps & IAntFormField;
+  }
+
+  private onChange (e: any) {
+    this.value = e.target.value.trim();
+    this.injected.onChange(this.value);
+  }
+
+  public render () {
+    return (
+      <Input value={this.value} {...this.props} onChange={this.onChange} />
+    );
+  }
+}
+
+export default TrimWhitespaceInput;

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -41,6 +41,7 @@ import ObjectSearch from '../inputs/ObjectSearch';
 import Hidden from '../inputs/Hidden';
 import Checkbox from '../inputs/Checkbox';
 import Address from '../inputs/Address';
+import TrimWhitespaceInput from '../inputs/TrimWhitespaceInput';
 
 function passRenderOnlyValue (func: (value: IValue) => React.ReactNode) {
   // tslint:disable-next-line no-unnecessary-callback-wrapper
@@ -132,6 +133,7 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
     render: passRenderOnlyValue(formatEmployerIdNumber),
   },
   email: {
+    editComponent: TrimWhitespaceInput,
     formValidationRules: {
       email: {
         message: 'Must be a valid email address',
@@ -248,7 +250,7 @@ export const TYPES: { [key: string]: Partial<IFieldConfig> } = {
     render: passRenderOnlyValue(parseAndPreserveNewlines),
   },
   url: {
-    editComponent: Antd.Input,
+    editComponent: TrimWhitespaceInput,
     render: passRenderOnlyValue(formatWebsite),
   },
 };

--- a/test/types/trimWhitespaceInput.test.ts
+++ b/test/types/trimWhitespaceInput.test.ts
@@ -1,0 +1,35 @@
+import * as faker from 'faker';
+
+import { Tester } from '@mighty-justice/tester';
+
+import { TYPE_GENERATORS, valueRenderPairs } from '../factories';
+
+import { FormCard } from '../../src';
+
+const { fieldConfigFactory } = TYPE_GENERATORS['email']
+    , fieldConfig = fieldConfigFactory.build()
+    , fieldSets = [[fieldConfig]]
+    , [value] = valueRenderPairs['email']
+    , model = { [fieldConfig.field]: value }
+    ;
+
+describe('TrimWhitespaceInput', () => {
+  it('trims whitespace', async () => {
+    const onSave = jest.fn()
+      , props = { fieldSets, model, onSave }
+      , fakeEmail = faker.internet.email()
+      , emailWithSpace = `       ${fakeEmail}      `
+      ;
+
+    // Renders formatted value
+    const tester = await new Tester(FormCard, { props }).mount();
+    expect(onSave).not.toHaveBeenCalled();
+    tester.changeInput(`input#${fieldConfig.field}`, emailWithSpace);
+
+    expect(tester.html()).not.toContain(emailWithSpace);
+    expect(tester.html()).toContain(fakeEmail);
+
+    tester.submit();
+    expect(onSave).toHaveBeenCalledWith({ [fieldConfig.field]: fakeEmail });
+  });
+});

--- a/test/types/trimWhitespaceInput.test.ts
+++ b/test/types/trimWhitespaceInput.test.ts
@@ -6,10 +6,10 @@ import { TYPE_GENERATORS, valueRenderPairs } from '../factories';
 
 import { FormCard } from '../../src';
 
-const { fieldConfigFactory } = TYPE_GENERATORS['email']
+const { fieldConfigFactory } = TYPE_GENERATORS.email
     , fieldConfig = fieldConfigFactory.build()
     , fieldSets = [[fieldConfig]]
-    , [value] = valueRenderPairs['email']
+    , [value] = valueRenderPairs.email
     , model = { [fieldConfig.field]: value }
     ;
 

--- a/test/types/trimWhitespaceInput.test.ts
+++ b/test/types/trimWhitespaceInput.test.ts
@@ -21,15 +21,17 @@ describe('TrimWhitespaceInput', () => {
       , emailWithSpace = `       ${fakeEmail}      `
       ;
 
-    // Renders formatted value
     const tester = await new Tester(FormCard, { props }).mount();
+
     expect(onSave).not.toHaveBeenCalled();
+
     tester.changeInput(`input#${fieldConfig.field}`, emailWithSpace);
 
     expect(tester.html()).not.toContain(emailWithSpace);
     expect(tester.html()).toContain(fakeEmail);
 
     tester.submit();
+
     expect(onSave).toHaveBeenCalledWith({ [fieldConfig.field]: fakeEmail });
   });
 });


### PR DESCRIPTION
If you copy and paste an email/website in the email/website fields and there is a space, it won’t let you save the email/website. This PR trims the spaces on both fields since there should never be whitespace on either

Will share Ngrok link upon request