### PR TITLE
Fix type of className

### DIFF
--- a/src/building-blocks/ButtonToolbar.tsx
+++ b/src/building-blocks/ButtonToolbar.tsx
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import cx from 'classnames';
+import { ClassValue } from 'classnames/types';
 
 import { Form } from 'antd';
 
 export interface IButtonToolbarProps {
   align?: 'between' | 'right';
-  className?: any;
+  className?: ClassValue;
   fixed?: boolean;
   noSpacing?: boolean;
 }

--- a/src/building-blocks/FieldSet.tsx
+++ b/src/building-blocks/FieldSet.tsx
@@ -2,19 +2,19 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import cx from 'classnames';
+import { ClassValue } from 'classnames/types';
 
 import * as Antd from 'antd';
 
 import { IFieldSetPartial } from '../interfaces';
-import { IClassName } from '../props';
 import { isPartialFieldSetSimple } from '../utilities';
 import { CLASS_PREFIX } from '../consts';
 
 import Legend from './Legend';
 
 interface IProps {
+  className?: ClassValue;
   fieldSet: IFieldSetPartial;
-  className?: IClassName;
 }
 
 const CLASS_NAME = `${CLASS_PREFIX}-field-set`;

--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import { values, omit, get } from 'lodash';
+import cx from 'classnames';
 
 import * as Antd from 'antd';
 import { ValidationRule as AntValidationRule } from 'antd/es/form';
@@ -100,7 +101,7 @@ class FormItem extends Component<IFormFieldProps> {
     return (
       <Antd.Col {...colProps}>
         <Antd.Form.Item
-          className={className}
+          className={cx(className)}
           {...this.formItemProps}
           {...formItemProps}
           label={renderLabel(fieldConfig)}

--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -94,16 +94,20 @@ class FormItem extends Component<IFormFieldProps> {
 
   public render () {
     const { formManager, fieldConfig } = this.props
-      , { className, colProps, formItemProps, field } = fieldConfig
+      , { colProps, formItemProps, field } = fieldConfig
+      , className = cx(
+        fieldConfig.className,
+        formItemProps && formItemProps.className,
+      )
       , { getFieldDecorator } = formManager.form
       ;
 
     return (
       <Antd.Col {...colProps}>
         <Antd.Form.Item
-          className={cx(className)}
           {...this.formItemProps}
           {...formItemProps}
+          className={className}
           label={renderLabel(fieldConfig)}
         >
           {getFieldDecorator(field, this.decoratorOptions)(this.props.children)}

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -3,11 +3,11 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import cx from 'classnames';
+import { ClassValue } from 'classnames/types';
 
 import * as Antd from 'antd';
 
 import { CLASS_PREFIX } from '../consts';
-import { IClassName } from '../props';
 import { IFieldConfig } from '../interfaces';
 
 @autoBindMethods
@@ -24,7 +24,7 @@ class Info extends Component<{ fieldConfig: IFieldConfig }> {
 
 @autoBindMethods
 @observer
-class Label extends Component<{ className?: IClassName }> {
+class Label extends Component<{ className?: ClassValue }> {
   public render () {
     return (
       <div className={cx(this.props.className, `${CLASS_PREFIX}-info-label`)}>
@@ -36,7 +36,7 @@ class Label extends Component<{ className?: IClassName }> {
 
 @autoBindMethods
 @observer
-class Value extends Component<{ className?: IClassName }> {
+class Value extends Component<{ className?: ClassValue }> {
   public render () {
     return (
       <div className={cx(this.props.className, `${CLASS_PREFIX}-info-value`)}>

--- a/src/inputs/Address.tsx
+++ b/src/inputs/Address.tsx
@@ -20,6 +20,7 @@ import {
 } from '../utilities';
 
 import { IModel } from '../props';
+import cx from 'classnames';
 
 export interface IAddressProps {
   fieldConfig: IFieldConfigAddress;
@@ -61,11 +62,17 @@ class Address extends Component<IAddressProps> {
   }
 
   public render () {
-    const { fieldConfig, formManager, formModel } = this.injected;
+    const { fieldConfig, formManager, formModel } = this.injected
+      , { colProps, formItemProps } = fieldConfig
+      , className = cx(
+        fieldConfig.className,
+        formItemProps && formItemProps.className,
+      )
+      ;
 
     return (
-      <Antd.Col>
-        <Antd.Form.Item className={fieldConfig.className}>
+      <Antd.Col {...colProps}>
+        <Antd.Form.Item className={className}>
           <NestedFieldSet
             fieldSet={this.fieldSet}
             formManager={formManager}

--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 import cx from 'classnames';
 import { pick } from 'lodash';
+import { ClassValue } from 'classnames/types';
 
 import SmartBool from '@mighty-justice/smart-bool';
 
@@ -37,7 +38,7 @@ export function isTypeObjectSearchCreate (fieldConfig: IFieldConfig): fieldConfi
 
 export interface IObjectSearchCreateProps {
   addNewContent?: React.ReactNode;
-  className?: string;
+  className?: ClassValue;
   debounceWait?: number;
   fieldConfig: IFieldConfigObjectSearchCreate;
   fieldDecorator: <T>(component: T) => T;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import { ColProps } from 'antd/es/col';
 import { ColumnProps } from 'antd/es/table';
 import { RowProps } from 'antd/es/row';
 import { ValidationRule as AntValidationRule, FormItemProps } from 'antd/es/form';
+import { ClassValue } from 'classnames/types';
 
 import { IModel, IValue } from './props';
 import { FormManager } from './utilities';
@@ -13,7 +14,7 @@ export interface IValidationRule extends AntValidationRule {
 }
 
 interface IFieldConfigBase {
-  className?: string;
+  className?: ClassValue;
   colProps?: ColProps;
   disabled: boolean;
   editComponent: any;

--- a/src/props.ts
+++ b/src/props.ts
@@ -37,7 +37,6 @@ export { IObjectSelectProps } from './inputs/ObjectSelect';
 
 import { IFieldSet, IFieldSetPartial } from './interfaces';
 
-export type IClassName = ClassValue[];
 export type IValue = any;
 
 export interface IModel {
@@ -47,7 +46,7 @@ export interface IModel {
 
 export interface ISharedComponentProps {
   children?: React.ReactNode;
-  className?: IClassName;
+  className?: ClassValue;
   classNameSuffix?: string;
   fieldSets: IFieldSet[] | IFieldSetPartial[];
   isLoading?: boolean;


### PR DESCRIPTION
**Bug:**
![image](https://user-images.githubusercontent.com/796717/77794082-a2848380-7041-11ea-9ca1-cf1e1ac69e99.png)

**Problem:** `export type IClassName = ClassValue[];` should be `ClassValue`

**Solution:** Just use `ClassValue` throughout library.