### PR TITLE
Add left-right label-data support

### DIFF
--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -88,3 +88,7 @@
   text-align: left;
   white-space: initial;
 }
+
+.fields-ant-info-item-inline {
+  display: flex;
+}

--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -99,6 +99,6 @@
   margin: 0 8px 0 2px;
 }
 
-.fields-ant-info-item-inline {
+.fields-ant-info-row-inline {
   display: flex;
 }

--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -79,7 +79,11 @@
   color: black;
 }
 
-.fields-ant-info-label, .fields-ant-info-label-no-colon {
+.fields-ant-info-row-inline {
+  display: flex;
+}
+
+.fields-ant-info-label {
   /* Copied from .ant-form-item-label */
   display: block;
   line-height: 1.5;
@@ -89,16 +93,12 @@
   white-space: initial;
 }
 
-.fields-ant-info-label-no-colon {
-  margin-right: 8px;
-}
-
-.fields-ant-info-label > label::after {
+.fields-ant-info-label-colon > label::after {
   content: ':';
   position: relative;
   margin: 0 8px 0 2px;
 }
 
-.fields-ant-info-row-inline {
-  display: flex;
+.fields-ant-info-label-no-colon > label {
+  margin-right: 8px;
 }

--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -79,7 +79,7 @@
   color: black;
 }
 
-.fields-ant-info-label {
+.fields-ant-info-label, .fields-ant-info-label-no-colon {
   /* Copied from .ant-form-item-label */
   display: block;
   line-height: 1.5;
@@ -87,6 +87,16 @@
   padding: 0 0 8px;
   text-align: left;
   white-space: initial;
+}
+
+.fields-ant-info-label-no-colon {
+  margin-right: 8px;
+}
+
+.fields-ant-info-label > label::after {
+  content: ':';
+  position: relative;
+  margin: 0 8px 0 2px;
 }
 
 .fields-ant-info-item-inline {

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -25,7 +25,7 @@ class CardField extends Component<ICardFieldProps> {
   public render() {
     const { colon, layout, model } = this.props,
       fieldConfig = this.fieldConfig,
-      format = {layout, colon};
+      format = { layout, colon };
 
     if (filterFieldConfig(fieldConfig, { model, writeOnly: true })) {
       return null;
@@ -34,7 +34,7 @@ class CardField extends Component<ICardFieldProps> {
     return (
       <Info fieldConfig={fieldConfig}>
         {fieldConfig.showLabel && <Label format={format}>{renderLabel(fieldConfig)}</Label>}
-        <Value format={format} >{renderValue(fieldConfig, model)}</Value>
+        <Value format={format}>{renderValue(fieldConfig, model)}</Value>
       </Info>
     );
   }

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -4,12 +4,12 @@ import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
 
 import { fillInFieldConfig, filterFieldConfig, renderLabel, renderValue } from '../utilities';
-import { IFieldConfigPartial } from '../interfaces';
+import { IFieldConfigPartial, IFormatProps } from '../interfaces';
 import { IModel } from '../props';
 
 import Info, { Label, Value } from './Info';
 
-export interface ICardFieldProps {
+export interface ICardFieldProps extends IFormatProps {
   fieldConfig: IFieldConfigPartial;
   model?: IModel;
 }
@@ -23,8 +23,9 @@ class CardField extends Component<ICardFieldProps> {
   }
 
   public render() {
-    const { model } = this.props,
-      fieldConfig = this.fieldConfig;
+    const { colon, layout, model } = this.props,
+      fieldConfig = this.fieldConfig,
+      format = {layout, colon};
 
     if (filterFieldConfig(fieldConfig, { model, writeOnly: true })) {
       return null;
@@ -32,8 +33,8 @@ class CardField extends Component<ICardFieldProps> {
 
     return (
       <Info fieldConfig={fieldConfig}>
-        {fieldConfig.showLabel && <Label>{renderLabel(fieldConfig)}</Label>}
-        <Value>{renderValue(fieldConfig, model)}</Value>
+        {fieldConfig.showLabel && <Label format={format}>{renderLabel(fieldConfig)}</Label>}
+        <Value format={format} >{renderValue(fieldConfig, model)}</Value>
       </Info>
     );
   }

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -34,7 +34,7 @@ class CardField extends Component<ICardFieldProps> {
     }
 
     return (
-      <Info format={passDownProps} fieldConfig={fieldConfig}>
+      <Info fieldConfig={fieldConfig} format={passDownProps}>
         {fieldConfig.showLabel && <Label format={passDownProps}>{renderLabel(fieldConfig)}</Label>}
         <Value>{renderValue(fieldConfig, model)}</Value>
       </Info>

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -8,6 +8,7 @@ import { IFieldConfigPartial, IFormatProps } from '../interfaces';
 import { IModel } from '../props';
 
 import Info, { Label, Value } from './Info';
+import { sharedComponentPropsDefaults } from '../propsDefaults';
 
 export interface ICardFieldProps extends IFormatProps {
   fieldConfig: IFieldConfigPartial;
@@ -17,6 +18,8 @@ export interface ICardFieldProps extends IFormatProps {
 @autoBindMethods
 @observer
 class CardField extends Component<ICardFieldProps> {
+  public static defaultProps: Partial<ICardFieldProps> = { ...sharedComponentPropsDefaults };
+
   @computed
   private get fieldConfig() {
     return fillInFieldConfig(this.props.fieldConfig);

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -26,17 +26,16 @@ class CardField extends Component<ICardFieldProps> {
   }
 
   public render() {
-    const { colon, layout, model } = this.props,
-      fieldConfig = this.fieldConfig,
-      format = { layout, colon };
+    const { model, ...passDownProps } = this.props,
+      fieldConfig = this.fieldConfig;
 
     if (filterFieldConfig(fieldConfig, { model, writeOnly: true })) {
       return null;
     }
 
     return (
-      <Info fieldConfig={fieldConfig} format={format}>
-        {fieldConfig.showLabel && <Label format={format}>{renderLabel(fieldConfig)}</Label>}
+      <Info format={passDownProps} fieldConfig={fieldConfig}>
+        {fieldConfig.showLabel && <Label format={passDownProps}>{renderLabel(fieldConfig)}</Label>}
         <Value>{renderValue(fieldConfig, model)}</Value>
       </Info>
     );

--- a/src/building-blocks/CardField.tsx
+++ b/src/building-blocks/CardField.tsx
@@ -32,9 +32,9 @@ class CardField extends Component<ICardFieldProps> {
     }
 
     return (
-      <Info fieldConfig={fieldConfig}>
+      <Info fieldConfig={fieldConfig} format={format}>
         {fieldConfig.showLabel && <Label format={format}>{renderLabel(fieldConfig)}</Label>}
-        <Value format={format}>{renderValue(fieldConfig, model)}</Value>
+        <Value>{renderValue(fieldConfig, model)}</Value>
       </Info>
     );
   }

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -25,7 +25,7 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
   }
 
   public render() {
-    const { model, fieldSet } = this.props,
+    const { model, fieldSet, ...passDownProps } = this.props,
       fieldConfigs = getFieldSetFields(this.fieldSet),
       filteredFieldConfigs = filterFieldConfigs(fieldConfigs, { model, writeOnly: true });
 
@@ -37,8 +37,7 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
       <FieldSet fieldSet={fieldSet}>
         {filteredFieldConfigs.map(fieldConfig => (
           <CardField
-            layout={this.props.layout}
-            colon={this.props.colon}
+            {...passDownProps}
             fieldConfig={fieldConfig}
             key={fieldConfig.field}
             model={model}

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -36,7 +36,13 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
     return (
       <FieldSet fieldSet={fieldSet}>
         {filteredFieldConfigs.map(fieldConfig => (
-          <CardField layout={this.props.layout} colon={this.props.colon} fieldConfig={fieldConfig} key={fieldConfig.field} model={model} />
+          <CardField
+            layout={this.props.layout}
+            colon={this.props.colon}
+            fieldConfig={fieldConfig}
+            key={fieldConfig.field}
+            model={model}
+          />
         ))}
       </FieldSet>
     );

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -6,12 +6,12 @@ import autoBindMethods from 'class-autobind-decorator';
 import { fillInFieldSet, filterFieldConfigs, getFieldSetFields } from '../utilities';
 
 import CardField from '../building-blocks/CardField';
-import { IFieldSetPartial } from '../interfaces';
+import { IFieldSetPartial, IFormatProps } from '../interfaces';
 import { IModel } from '../props';
 
 import FieldSet from './FieldSet';
 
-export interface ICardFieldSetProps {
+export interface ICardFieldSetProps extends IFormatProps {
   fieldSet: IFieldSetPartial;
   model?: IModel;
 }
@@ -36,7 +36,7 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
     return (
       <FieldSet fieldSet={fieldSet}>
         {filteredFieldConfigs.map(fieldConfig => (
-          <CardField fieldConfig={fieldConfig} key={fieldConfig.field} model={model} />
+          <CardField layout={this.props.layout} colon={this.props.colon} fieldConfig={fieldConfig} key={fieldConfig.field} model={model} />
         ))}
       </FieldSet>
     );

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -36,12 +36,7 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
     return (
       <FieldSet fieldSet={fieldSet}>
         {filteredFieldConfigs.map(fieldConfig => (
-          <CardField
-            {...passDownProps}
-            fieldConfig={fieldConfig}
-            key={fieldConfig.field}
-            model={model}
-          />
+          <CardField {...passDownProps} fieldConfig={fieldConfig} key={fieldConfig.field} model={model} />
         ))}
       </FieldSet>
     );

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -16,7 +16,7 @@ class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IForma
   public render() {
     const { format } = this.props,
       layout = format && format.layout,
-      rowClassName = layout !== 'inline' ? '' : `${CLASS_PREFIX}-info-item-inline`;
+      rowClassName = `${CLASS_PREFIX}-info-row-${layout}`;
 
     return (
       <Antd.Col {...this.props.fieldConfig.colProps} className={`${CLASS_PREFIX}-info`}>

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -8,7 +8,8 @@ import { ClassValue } from 'classnames/types';
 import * as Antd from 'antd';
 
 import { CLASS_PREFIX } from '../consts';
-import { IFieldConfigPartial } from '../interfaces';
+import { IFieldConfigPartial, IFormatProps } from '../interfaces';
+import { getLabelAfter } from '../utilities/common';
 
 @autoBindMethods
 @observer
@@ -24,17 +25,38 @@ class Info extends Component<{ fieldConfig: IFieldConfigPartial }> {
 
 @autoBindMethods
 @observer
-class Label extends Component<{ className?: ClassValue }> {
+class Label extends Component<{ className?: ClassValue, format?: IFormatProps }> {
   public render() {
-    return <div className={cx(this.props.className, `${CLASS_PREFIX}-info-label`)}>{this.props.children}</div>;
+    const { className, format } = this.props
+      , colon = format && format.colon
+      , layout = format && format.layout
+      , colonText = colon === false ? '' : ':'
+      , labelClassName = cx(className, `${CLASS_PREFIX}-info-label`)
+      , labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
+
+    return layout === "inline"
+      ? <div style={{"float": "left"}} className={labelClassName}>
+          {this.props.children}
+          {getLabelAfter(labelAfterClassName, colonText)}
+        </div>
+      : <div className={labelClassName}>
+          {this.props.children}
+          {getLabelAfter(labelAfterClassName, colonText)}
+        </div>;
   }
 }
 
 @autoBindMethods
 @observer
-class Value extends Component<{ className?: ClassValue }> {
+class Value extends Component<{ className?: ClassValue, format?: IFormatProps }> {
   public render() {
-    return <div className={cx(this.props.className, `${CLASS_PREFIX}-info-value`)}>{this.props.children}</div>;
+    const { format } = this.props
+      , layout = format && format.layout
+      , className = cx(this.props.className, `${CLASS_PREFIX}-info-value`);
+
+    return layout === "inline"
+      ? <div style={{"float": "left"}} className={className}>{this.props.children}</div>
+      : <div className={className}>{this.props.children}</div>;
   }
 }
 

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -40,7 +40,7 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
         `${CLASS_PREFIX}-info-label`,
         `${CLASS_PREFIX}-info-label${hasColon ? '' : '-no'}-colon`,
         `${CLASS_PREFIX}-info-label-layout-${layout}`,
-      )
+      );
 
     return (
       <div className={labelClassName}>

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -25,38 +25,44 @@ class Info extends Component<{ fieldConfig: IFieldConfigPartial }> {
 
 @autoBindMethods
 @observer
-class Label extends Component<{ className?: ClassValue, format?: IFormatProps }> {
+class Label extends Component<{ className?: ClassValue; format?: IFormatProps }> {
   public render() {
-    const { className, format } = this.props
-      , colon = format && format.colon
-      , layout = format && format.layout
-      , colonText = colon === false ? '' : ':'
-      , labelClassName = cx(className, `${CLASS_PREFIX}-info-label`)
-      , labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
+    const { className, format } = this.props,
+      colon = format && format.colon,
+      layout = format && format.layout,
+      colonText = colon === false ? '' : ':',
+      labelClassName = cx(className, `${CLASS_PREFIX}-info-label`),
+      labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
 
-    return layout !== "inline"
-      ? <div className={labelClassName}>
-          {this.props.children}
-          {getLabelAfter(labelAfterClassName, colonText)}
-        </div>
-      : <div style={{"float": "left"}} className={labelClassName}>
-          {this.props.children}
-          {getLabelAfter(labelAfterClassName, colonText)}
-        </div>;
+    return layout !== 'inline' ? (
+      <div className={labelClassName}>
+        {this.props.children}
+        {getLabelAfter(labelAfterClassName, colonText)}
+      </div>
+    ) : (
+      <div style={{ float: 'left' }} className={labelClassName}>
+        {this.props.children}
+        {getLabelAfter(labelAfterClassName, colonText)}
+      </div>
+    );
   }
 }
 
 @autoBindMethods
 @observer
-class Value extends Component<{ className?: ClassValue, format?: IFormatProps }> {
+class Value extends Component<{ className?: ClassValue; format?: IFormatProps }> {
   public render() {
-    const { format } = this.props
-      , layout = format && format.layout
-      , className = cx(this.props.className, `${CLASS_PREFIX}-info-value`);
+    const { format } = this.props,
+      layout = format && format.layout,
+      className = cx(this.props.className, `${CLASS_PREFIX}-info-value`);
 
-    return layout === "inline"
-      ? <div style={{"float": "left"}} className={className}>{this.props.children}</div>
-      : <div className={className}>{this.props.children}</div>;
+    return layout === 'inline' ? (
+      <div style={{ float: 'left' }} className={className}>
+        {this.props.children}
+      </div>
+    ) : (
+      <div className={className}>{this.props.children}</div>
+    );
   }
 }
 

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -16,15 +16,12 @@ import { getLabelAfter } from '../utilities/common';
 class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IFormatProps }> {
   public render() {
     const { format } = this.props,
-      layout = format && format.layout;
+      layout = format && format.layout,
+      rowClassName = layout !== 'inline' ? '' : `${CLASS_PREFIX}-info-item-inline`;
 
     return (
       <Antd.Col {...this.props.fieldConfig.colProps} className={`${CLASS_PREFIX}-info`}>
-        {layout !== 'inline' ? (
-          this.props.children
-        ) : (
-          <Antd.Row style={{ display: 'flex' }}>{this.props.children}</Antd.Row>
-        )}
+        <Antd.Row className={rowClassName}>{this.props.children}</Antd.Row>
       </Antd.Col>
     );
   }

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -34,9 +34,13 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
       colon = format && format.colon,
       layout = format && format.layout,
       // colon can be displayed only when layout is inline or horizontal
-      colonClassName =
-        colon === false || layout === 'vertical' ? `${CLASS_PREFIX}-info-label-no-colon` : `${CLASS_PREFIX}-info-label`,
-      labelClassName = cx(className, colonClassName);
+      hasColon = !(colon === false || layout === 'vertical'),
+      labelClassName = cx(
+        className,
+        `${CLASS_PREFIX}-info-label`,
+        `${CLASS_PREFIX}-info-label${hasColon ? '' : '-no'}-colon`,
+        `${CLASS_PREFIX}-info-label-layout-${layout}`,
+      )
 
     return (
       <div className={labelClassName}>

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -32,7 +32,10 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
   public render() {
     const { className, format } = this.props,
       colon = format && format.colon,
-      colonClassName = colon === false ? `${CLASS_PREFIX}-info-label-no-colon` : `${CLASS_PREFIX}-info-label`,
+      layout = format && format.layout,
+      // colon can be displayed only when layout is inline or horizontal
+      colonClassName =
+        colon === false || layout === 'vertical' ? `${CLASS_PREFIX}-info-label-no-colon` : `${CLASS_PREFIX}-info-label`,
       labelClassName = cx(className, colonClassName);
 
     return (

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -9,7 +9,6 @@ import * as Antd from 'antd';
 
 import { CLASS_PREFIX } from '../consts';
 import { IFieldConfigPartial, IFormatProps } from '../interfaces';
-import { getLabelAfter } from '../utilities/common';
 
 @autoBindMethods
 @observer
@@ -33,14 +32,12 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
   public render() {
     const { className, format } = this.props,
       colon = format && format.colon,
-      colonText = colon === false ? '' : ':',
-      labelClassName = cx(className, `${CLASS_PREFIX}-info-label`),
-      labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
+      colonClassName = colon === false ? `${CLASS_PREFIX}-info-label-no-colon` : `${CLASS_PREFIX}-info-label`,
+      labelClassName = cx(className, colonClassName);
 
     return (
       <div className={labelClassName}>
-        {this.props.children}
-        {getLabelAfter(labelAfterClassName, colonText)}
+        <label>{this.props.children}</label>
       </div>
     );
   }

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -13,11 +13,18 @@ import { getLabelAfter } from '../utilities/common';
 
 @autoBindMethods
 @observer
-class Info extends Component<{ fieldConfig: IFieldConfigPartial }> {
+class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IFormatProps }> {
   public render() {
+    const { format } = this.props,
+      layout = format && format.layout;
+
     return (
       <Antd.Col {...this.props.fieldConfig.colProps} className={`${CLASS_PREFIX}-info`}>
-        {this.props.children}
+        {layout !== 'inline' ? (
+          this.props.children
+        ) : (
+          <Antd.Row style={{ display: 'flex' }}>{this.props.children}</Antd.Row>
+        )}
       </Antd.Col>
     );
   }
@@ -29,18 +36,12 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
   public render() {
     const { className, format } = this.props,
       colon = format && format.colon,
-      layout = format && format.layout,
       colonText = colon === false ? '' : ':',
       labelClassName = cx(className, `${CLASS_PREFIX}-info-label`),
       labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
 
-    return layout !== 'inline' ? (
+    return (
       <div className={labelClassName}>
-        {this.props.children}
-        {getLabelAfter(labelAfterClassName, colonText)}
-      </div>
-    ) : (
-      <div style={{ float: 'left' }} className={labelClassName}>
         {this.props.children}
         {getLabelAfter(labelAfterClassName, colonText)}
       </div>
@@ -50,19 +51,9 @@ class Label extends Component<{ className?: ClassValue; format?: IFormatProps }>
 
 @autoBindMethods
 @observer
-class Value extends Component<{ className?: ClassValue; format?: IFormatProps }> {
+class Value extends Component<{ className?: ClassValue }> {
   public render() {
-    const { format } = this.props,
-      layout = format && format.layout,
-      className = cx(this.props.className, `${CLASS_PREFIX}-info-value`);
-
-    return layout === 'inline' ? (
-      <div style={{ float: 'left' }} className={className}>
-        {this.props.children}
-      </div>
-    ) : (
-      <div className={className}>{this.props.children}</div>
-    );
+    return <div className={cx(this.props.className, `${CLASS_PREFIX}-info-value`)}>{this.props.children}</div>;
   }
 }
 

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -34,12 +34,12 @@ class Label extends Component<{ className?: ClassValue, format?: IFormatProps }>
       , labelClassName = cx(className, `${CLASS_PREFIX}-info-label`)
       , labelAfterClassName = cx(className, `${CLASS_PREFIX}-info-label-after`);
 
-    return layout === "inline"
-      ? <div style={{"float": "left"}} className={labelClassName}>
+    return layout !== "inline"
+      ? <div className={labelClassName}>
           {this.props.children}
           {getLabelAfter(labelAfterClassName, colonText)}
         </div>
-      : <div className={labelClassName}>
+      : <div style={{"float": "left"}} className={labelClassName}>
           {this.props.children}
           {getLabelAfter(labelAfterClassName, colonText)}
         </div>;

--- a/src/components/ArrayCard.tsx
+++ b/src/components/ArrayCard.tsx
@@ -17,14 +17,21 @@ export interface IArrayCardProps extends ICardProps {
 @observer
 class ArrayCard extends Component<IArrayCardProps> {
   public render() {
-    const { title, renderTopRight, isLoading, model, fieldSets, classNameSuffix } = this.props;
+    const { title, renderTopRight, isLoading, model, fieldSets, classNameSuffix, ...passDownProps } = this.props;
 
     return (
       <Antd.Card title={title} extra={renderTopRight && renderTopRight()} loading={isLoading}>
         {isEmpty(model) && <p className="empty-message">No records</p>}
 
         {model.map((modelItem: any) => (
-          <Card classNameSuffix={classNameSuffix} fieldSets={fieldSets} key={modelItem.id} model={modelItem} title="" />
+          <Card
+            {...passDownProps}
+            classNameSuffix={classNameSuffix}
+            fieldSets={fieldSets}
+            key={modelItem.id}
+            model={modelItem}
+            title=""
+          />
         ))}
       </Antd.Card>
     );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -26,7 +26,7 @@ class Card extends Component<ICardProps> {
   }
 
   public render() {
-    const { className, title, renderTopRight, isLoading, model } = this.props,
+    const { className, title, renderTopRight, isLoading, model, layout, colon } = this.props,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model, writeOnly: true });
 
     return (
@@ -37,7 +37,7 @@ class Card extends Component<ICardProps> {
         title={title}
       >
         {filteredFieldSets.map((fieldSet, idx) => (
-          <CardFieldSet fieldSet={fieldSet} key={idx} model={model} />
+          <CardFieldSet layout={layout} colon={colon} fieldSet={fieldSet} key={idx} model={model} />
         ))}
 
         {this.props.children}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -26,7 +26,7 @@ class Card extends Component<ICardProps> {
   }
 
   public render() {
-    const { className, title, renderTopRight, isLoading, model, layout, colon } = this.props,
+    const { className, title, renderTopRight, isLoading, model, ...passDownProps } = this.props,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model, writeOnly: true });
 
     return (
@@ -37,7 +37,7 @@ class Card extends Component<ICardProps> {
         title={title}
       >
         {filteredFieldSets.map((fieldSet, idx) => (
-          <CardFieldSet layout={layout} colon={colon} fieldSet={fieldSet} key={idx} model={model} />
+          <CardFieldSet {...passDownProps} fieldSet={fieldSet} key={idx} model={model} />
         ))}
 
         {this.props.children}

--- a/src/components/EditableArrayCard.tsx
+++ b/src/components/EditableArrayCard.tsx
@@ -60,7 +60,18 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
   }
 
   public render() {
-    const { classNameSuffix, defaults, fieldSets, isLoading, model, onDelete, onSave, onSuccess, title } = this.props;
+    const {
+      classNameSuffix,
+      defaults,
+      fieldSets,
+      isLoading,
+      model,
+      onDelete,
+      onSave,
+      onSuccess,
+      title,
+      ...passDownProps
+    } = this.props;
 
     return (
       <Antd.Card title={title} extra={this.renderAddNew()} loading={isLoading}>
@@ -78,6 +89,7 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
 
         {model.map(modelItem => (
           <EditableCard
+            {...passDownProps}
             classNameSuffix={classNameSuffix}
             fieldSets={fieldSets}
             key={modelItem.id}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -94,7 +94,8 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     const { showControls, title, layout, colon } = this.props,
       formModel = this.formManager.formModel,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel }),
-      className = cx(CLASS_NAME, this.props.className);
+      hasColon = !(colon === false || layout === 'vertical'),
+      className = cx(CLASS_NAME, this.props.className, `fields-ant-form${hasColon ? '' : '-no'}-colon`);
 
     return (
       <Antd.Form className={className} colon={colon} layout={layout} onSubmit={this.formManager.onSave}>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -97,7 +97,12 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
       className = cx(CLASS_NAME, this.props.className);
 
     return (
-      <Antd.Form layout={layout || "inline"} onSubmit={this.formManager.onSave} className={className} colon={colon === false ? false : true}>
+      <Antd.Form
+        layout={layout || 'inline'}
+        onSubmit={this.formManager.onSave}
+        className={className}
+        colon={colon === false ? false : true}
+      >
         {title && <h2>{title}</h2>}
 
         {filteredFieldSets.map((fieldSet, idx) => (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -91,13 +91,13 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
   }
 
   public render() {
-    const { showControls, title } = this.props,
+    const { showControls, title, layout, colon } = this.props,
       formModel = this.formManager.formModel,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel }),
       className = cx(CLASS_NAME, this.props.className);
 
     return (
-      <Antd.Form layout="vertical" onSubmit={this.formManager.onSave} className={className}>
+      <Antd.Form layout={layout || "inline"} onSubmit={this.formManager.onSave} className={className} colon={colon === false ? false : true}>
         {title && <h2>{title}</h2>}
 
         {filteredFieldSets.map((fieldSet, idx) => (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -12,7 +12,7 @@ import { FormComponentProps } from 'antd/es/form';
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
 import FormFieldSet from '../building-blocks/FormFieldSet';
 import { fillInFieldSets, filterFieldSets, FormManager } from '../utilities';
-import { formPropsDefaults } from '../propsDefaults';
+import { formPropsDefaults, sharedComponentPropsDefaults } from '../propsDefaults';
 import { ISharedFormProps, ISharedComponentProps } from '../props';
 import { CLASS_PREFIX } from '../consts';
 
@@ -98,7 +98,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
 
     return (
       <Antd.Form
-        layout={layout || 'horizontal'}
+        layout={layout}
         onSubmit={this.formManager.onSave}
         className={className}
         colon={colon === false ? false : true}
@@ -125,6 +125,7 @@ const WrappedForm = Antd.Form.create()(UnwrappedForm);
 export class Form extends Component<IFormProps> {
   public static defaultProps: Partial<IFormWrappedProps> = {
     ...formPropsDefaults,
+    ...sharedComponentPropsDefaults,
     showControls: true,
   };
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -98,7 +98,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
 
     return (
       <Antd.Form
-        layout={layout || 'inline'}
+        layout={layout || 'horizontal'}
         onSubmit={this.formManager.onSave}
         className={className}
         colon={colon === false ? false : true}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -97,12 +97,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
       className = cx(CLASS_NAME, this.props.className);
 
     return (
-      <Antd.Form
-        layout={layout}
-        onSubmit={this.formManager.onSave}
-        className={className}
-        colon={colon === false ? false : true}
-      >
+      <Antd.Form className={className} colon={colon} layout={layout} onSubmit={this.formManager.onSave}>
         {title && <h2>{title}</h2>}
 
         {filteredFieldSets.map((fieldSet, idx) => (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -147,7 +147,9 @@ export interface IEndpointOption {
   id: string;
 }
 
+export type ILayout = "horizontal" | "inline" | "vertical";
+
 export interface IFormatProps {
-  layout?: "horizontal" | "inline" | "vertical";
+  layout?: ILayout;
   colon?: boolean;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -147,7 +147,7 @@ export interface IEndpointOption {
   id: string;
 }
 
-export type ILayout = "horizontal" | "inline" | "vertical";
+export type ILayout = 'horizontal' | 'inline' | 'vertical';
 
 export interface IFormatProps {
   layout?: ILayout;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -146,3 +146,8 @@ export interface ICheckboxProps extends IInputProps {
 export interface IEndpointOption {
   id: string;
 }
+
+export interface IFormatProps {
+  layout?: "horizontal" | "inline" | "vertical";
+  colon?: boolean;
+}

--- a/src/props.ts
+++ b/src/props.ts
@@ -14,7 +14,7 @@ import { IBackendValidation } from './utilities/FormManager';
 // All below props are shared / inherited by components
 // This allows us to keep the library consistent and uniform
 
-import { IFieldSet, IFieldSetPartial, ILayout } from './interfaces';
+import { IFieldSet, IFieldSetPartial, IFormatProps } from './interfaces';
 
 export { IButtonToolbarProps } from './building-blocks/ButtonToolbar';
 export { ICardFieldProps } from './building-blocks/CardField';
@@ -44,7 +44,7 @@ export interface IModel {
   id?: string;
 }
 
-export interface ISharedComponentProps {
+export interface ISharedComponentProps extends IFormatProps {
   children?: React.ReactNode;
   className?: ClassValue;
   classNameSuffix?: string;
@@ -52,8 +52,6 @@ export interface ISharedComponentProps {
   isLoading?: boolean;
   model?: IModel;
   title?: React.ReactNode;
-  layout?: ILayout;
-  colon?: boolean;
 }
 
 export interface ISharedFormProps {
@@ -69,7 +67,6 @@ export interface ISharedFormProps {
   resetOnSuccess?: boolean;
   saveText: string;
   successText?: null | string;
-  layout?: ILayout;
 }
 
 export interface ISharedFormModalProps extends ISharedComponentProps, ISharedFormProps {

--- a/src/props.ts
+++ b/src/props.ts
@@ -52,6 +52,8 @@ export interface ISharedComponentProps {
   isLoading?: boolean;
   model?: IModel;
   title?: React.ReactNode;
+  layout?: "inline" | "horizontal" | "vertical";
+  colon?: boolean;
 }
 
 export interface ISharedFormProps {
@@ -67,6 +69,7 @@ export interface ISharedFormProps {
   resetOnSuccess?: boolean;
   saveText: string;
   successText?: null | string;
+  layout?: "inline" | "horizontal" | "vertical";
 }
 
 export interface ISharedFormModalProps extends ISharedComponentProps, ISharedFormProps {

--- a/src/props.ts
+++ b/src/props.ts
@@ -14,7 +14,7 @@ import { IBackendValidation } from './utilities/FormManager';
 // All below props are shared / inherited by components
 // This allows us to keep the library consistent and uniform
 
-import { IFieldSet, IFieldSetPartial } from './interfaces';
+import { IFieldSet, IFieldSetPartial, ILayout } from './interfaces';
 
 export { IButtonToolbarProps } from './building-blocks/ButtonToolbar';
 export { ICardFieldProps } from './building-blocks/CardField';
@@ -52,7 +52,7 @@ export interface ISharedComponentProps {
   isLoading?: boolean;
   model?: IModel;
   title?: React.ReactNode;
-  layout?: "inline" | "horizontal" | "vertical";
+  layout?: ILayout;
   colon?: boolean;
 }
 
@@ -69,7 +69,7 @@ export interface ISharedFormProps {
   resetOnSuccess?: boolean;
   saveText: string;
   successText?: null | string;
-  layout?: "inline" | "horizontal" | "vertical";
+  layout?: ILayout;
 }
 
 export interface ISharedFormModalProps extends ISharedComponentProps, ISharedFormProps {

--- a/src/propsDefaults.ts
+++ b/src/propsDefaults.ts
@@ -1,4 +1,4 @@
-import { ILayout } from "./interfaces";
+import { ILayout } from './interfaces';
 
 // istanbul ignore next
 async function asyncNoop() {
@@ -12,7 +12,7 @@ export const formPropsDefaults = {
   saveText: 'Save',
 };
 
-export const sharedComponentPropsDefaults: { layout?: ILayout, colon: boolean} = {
+export const sharedComponentPropsDefaults: { layout?: ILayout; colon: boolean } = {
   layout: 'vertical',
   colon: false,
 };

--- a/src/propsDefaults.ts
+++ b/src/propsDefaults.ts
@@ -1,3 +1,5 @@
+import { ILayout } from "./interfaces";
+
 // istanbul ignore next
 async function asyncNoop() {
   // istanbul ignore next
@@ -8,4 +10,9 @@ export const formPropsDefaults = {
   cancelText: 'Cancel',
   onSave: asyncNoop,
   saveText: 'Save',
+};
+
+export const sharedComponentPropsDefaults: { layout?: ILayout, colon: boolean} = {
+  layout: 'vertical',
+  colon: false,
 };

--- a/src/utilities/common.tsx
+++ b/src/utilities/common.tsx
@@ -197,11 +197,3 @@ export function getBtnClassName(action: string, classNameSuffix?: string, title?
     [`${prefix}-${classNameSuffix}`]: !!classNameSuffix,
   });
 }
-
-export function getLabelAfter(className: string, value: string) {
-  return (
-    <span className={className} style={{ position: 'relative', top: '-0.5px', margin: '0 8px 0 2px' }}>
-      {value}
-    </span>
-  );
-}

--- a/src/utilities/common.tsx
+++ b/src/utilities/common.tsx
@@ -200,7 +200,7 @@ export function getBtnClassName(action: string, classNameSuffix?: string, title?
 
 export function getLabelAfter(className: string, value: string) {
   return (
-    <span className={className} style={{position: 'relative', top: '-0.5px', margin: '0 8px 0 2px'}}>
+    <span className={className} style={{ position: 'relative', top: '-0.5px', margin: '0 8px 0 2px' }}>
       {value}
     </span>
   );

--- a/src/utilities/common.tsx
+++ b/src/utilities/common.tsx
@@ -197,3 +197,11 @@ export function getBtnClassName(action: string, classNameSuffix?: string, title?
     [`${prefix}-${classNameSuffix}`]: !!classNameSuffix,
   });
 }
+
+export function getLabelAfter(className: string, value: string) {
+  return (
+    <span className={className} style={{position: 'relative', top: '-0.5px', margin: '0 8px 0 2px'}}>
+      {value}
+    </span>
+  );
+}

--- a/stories/3_features.stories.tsx
+++ b/stories/3_features.stories.tsx
@@ -14,7 +14,8 @@ storiesOf('Features', module)
     <>
       <FormCard
         {...formCardPropsFactory.build()}
-        layout="vertical"
+        layout="inline"
+        colon
         fieldSets={[{
           fields: [
             {
@@ -39,7 +40,7 @@ storiesOf('Features', module)
       <EditableCard
         {...formCardPropsFactory.build()}
         layout='inline'
-        colon={false}
+        colon
         fieldSets={[
           {
             fields: [

--- a/stories/3_features.stories.tsx
+++ b/stories/3_features.stories.tsx
@@ -10,6 +10,71 @@ import { IModel } from '../src/props';
 
 storiesOf('Features', module)
   .addDecorator(withInfoConfigured)
+  .add('display', () => (
+    <>
+      <FormCard
+        {...formCardPropsFactory.build()}
+        layout="vertical"
+        fieldSets={[{
+          fields: [
+            {
+              ...objectSearchCreateFactory.build() as IFieldConfigObjectSearchCreate,
+              colProps: { sm: 24, lg: 12 } as ColProps,
+              createFields: [
+                { field: 'first_name', populateFromSearch: true },
+                { field: 'last_name', populateNameFromSearch: true },
+                { field: 'lawfirm', populateFromSearch: true },
+                {
+                  createFields: [{ field: 'name' }],
+                  field: 'organization',
+                  type: 'objectSearchCreate',
+                },
+              ],
+            },
+          ],
+          legend: 'Legend Text',
+          rowProps: { gutter: 16 },
+        }]}
+      />
+      <EditableCard
+        {...formCardPropsFactory.build()}
+        layout='inline'
+        colon={false}
+        fieldSets={[
+          {
+            fields: [
+              ...fieldFactory.buildList(6).map(fieldConfig => ({
+                ...fieldConfig,
+                colProps: { sm: 12, lg: 6 },
+              })),
+            ],
+            legend: 'Four across',
+            rowProps: { gutter: 16 },
+          },
+          {
+            fields: [
+              ...fieldFactory.buildList(6).map(fieldConfig => ({
+                ...fieldConfig,
+                colProps: { sm: 24, lg: 12 },
+              })),
+            ],
+            legend: 'Two across',
+            rowProps: { gutter: 16 },
+          },
+          {
+            fields: [
+              ...fieldFactory.buildList(6).map(fieldConfig => ({
+                ...fieldConfig,
+                colProps: { sm: 24, lg: 24 },
+              })),
+            ],
+            legend: 'One across',
+            rowProps: { gutter: 16 },
+          },
+        ]}
+      />
+    </>
+  ))
   .add('populateFromSearch', () => (
     <FormCard
       {...formCardPropsFactory.build()}

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -56,6 +56,22 @@ describe('Renders', () => {
 
         expect(tester.find(`form.ant-form-${layout}`).length).toBe(1);
       });
+
+      it(`Displays colon properly for ${layout} ${componentName}`, async () => {
+        const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+          props = propsFactory.build({
+            fieldSets,
+            layout,
+            colon: true,
+          }),
+          tester = await new Tester(ComponentClass, { props }).mount();
+
+        if (layout === 'vertical') {
+          expect(tester.find('form.fields-ant-form-no-colon').length).toBe(1);
+        } else {
+          expect(tester.find('form.fields-ant-form-colon').length).toBe(1);
+        }
+      });
     });
   });
 

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -1,0 +1,81 @@
+import { Tester } from '@mighty-justice/tester';
+import { COMPONENT_GENERATORS, fakeField, fakeTextShort } from '../factories';
+
+const normalFieldSet = { field: fakeField(), label: fakeTextShort(), type: 'string' },
+  EDITABLE_COMPONENTS = ['EditableCard', 'EditableArrayCard'],
+  COMPONENTS = [
+    ...EDITABLE_COMPONENTS,
+    'ArrayCard',
+    'FormCard',
+    'SummaryCard',
+    'Card',
+    'Form',
+    'FormModal',
+    'FormDrawer',
+  ],
+  LAYOUTS = ['inline', 'vertical', 'horizontal'];
+
+function isForm(tester: any) {
+  return !!tester.find('button[type="submit"]').length;
+}
+
+describe('Renders', () => {
+  COMPONENTS.forEach(componentName => {
+    LAYOUTS.forEach(layout => {
+      it(`Displays ${layout} for ${componentName}`, async () => {
+        const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+          props = propsFactory.build({
+            fieldSets: [[normalFieldSet]],
+            layout: layout,
+          }),
+          tester = await new Tester(ComponentClass, { props }).mount();
+
+        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
+        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+      });
+    });
+  });
+
+  COMPONENTS.forEach(componentName => {
+    LAYOUTS.forEach(layout => {
+      it(`Displays colon properly for ${layout} ${componentName}`, async () => {
+        const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+          props = propsFactory.build({
+            fieldSets: [[normalFieldSet]],
+            layout: layout,
+            colon: true,
+          }),
+          tester = await new Tester(ComponentClass, { props }).mount();
+
+        if (layout === 'vertical') {
+          expect(tester.find('.fields-ant-info-label-no-colon').length);
+        } else {
+          expect(tester.find('.fields-ant-info-label-colon').length);
+        }
+      });
+    });
+  });
+
+  EDITABLE_COMPONENTS.forEach(componentName => {
+    LAYOUTS.forEach(layout => {
+      it(`Displays ${layout} when reading and writing for ${componentName}`, async () => {
+        const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+          props = propsFactory.build({
+            fieldSets: [[normalFieldSet]],
+            layout: layout,
+          }),
+          tester = await new Tester(ComponentClass, { props }).mount();
+
+        expect(isForm(tester)).toBe(false);
+        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
+        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+
+        tester.click(`button.btn-edit`);
+
+        expect(isForm(tester)).toBe(true);
+        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
+        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+      });
+    });
+  });
+});

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -1,7 +1,7 @@
 import { Tester } from '@mighty-justice/tester';
-import { COMPONENT_GENERATORS, fakeField, fakeTextShort } from '../factories';
+import { COMPONENT_GENERATORS, stringFactory } from '../factories';
 
-const normalFieldSet = { field: fakeField(), label: fakeTextShort(), type: 'string' },
+const fieldSets = [[stringFactory.build()]],
   EDITABLE_COMPONENTS = ['EditableCard', 'EditableArrayCard'],
   COMPONENTS = [
     ...EDITABLE_COMPONENTS,
@@ -25,8 +25,8 @@ describe('Renders', () => {
       it(`Displays ${layout} for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
           props = propsFactory.build({
-            fieldSets: [[normalFieldSet]],
-            layout: layout,
+            fieldSets,
+            layout,
           }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
@@ -41,8 +41,8 @@ describe('Renders', () => {
       it(`Displays colon properly for ${layout} ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
           props = propsFactory.build({
-            fieldSets: [[normalFieldSet]],
-            layout: layout,
+            fieldSets,
+            layout,
             colon: true,
           }),
           tester = await new Tester(ComponentClass, { props }).mount();
@@ -61,8 +61,8 @@ describe('Renders', () => {
       it(`Displays ${layout} when reading and writing for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
           props = propsFactory.build({
-            fieldSets: [[normalFieldSet]],
-            layout: layout,
+            fieldSets,
+            layout,
           }),
           tester = await new Tester(ComponentClass, { props }).mount();
 

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -13,6 +13,33 @@ function isForm(tester: any) {
 
 describe('Renders', () => {
   CARD_COMPONENTS.forEach(componentName => {
+    it(`defaults ${componentName} correctly`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+        props = propsFactory.build({
+          fieldSets,
+        }),
+        tester = await new Tester(ComponentClass, { props }).mount();
+
+      expect(tester.find(`div.fields-ant-info-row-vertical`).length).toBe(1);
+      expect(tester.find(`.fields-ant-info-label-layout-vertical`).length).toBe(1);
+      expect(tester.find('.fields-ant-info-label-no-colon').length).toBe(1);
+    });
+  });
+
+  FORM_COMPONENTS.forEach(componentName => {
+    it(`defaults ${componentName} correctly`, async () => {
+      const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+        props = propsFactory.build({
+          fieldSets,
+        }),
+        tester = await new Tester(ComponentClass, { props }).mount();
+
+      expect(tester.find(`form.ant-form-vertical`).length).toBe(1);
+      expect(tester.find('form.fields-ant-form-no-colon').length).toBe(1);
+    });
+  });
+
+  CARD_COMPONENTS.forEach(componentName => {
     LAYOUTS.forEach(layout => {
       it(`Displays ${layout} for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -2,17 +2,9 @@ import { Tester } from '@mighty-justice/tester';
 import { COMPONENT_GENERATORS, stringFactory } from '../factories';
 
 const fieldSets = [[stringFactory.build()]],
+  FORM_COMPONENTS = ['Form', 'FormCard', 'FormModal', 'FormDrawer'],
   EDITABLE_COMPONENTS = ['EditableCard', 'EditableArrayCard'],
-  COMPONENTS = [
-    ...EDITABLE_COMPONENTS,
-    'ArrayCard',
-    'FormCard',
-    'SummaryCard',
-    'Card',
-    'Form',
-    'FormModal',
-    'FormDrawer',
-  ],
+  CARD_COMPONENTS = [...EDITABLE_COMPONENTS, 'Card', 'ArrayCard'],
   LAYOUTS = ['inline', 'vertical', 'horizontal'];
 
 function isForm(tester: any) {
@@ -20,7 +12,7 @@ function isForm(tester: any) {
 }
 
 describe('Renders', () => {
-  COMPONENTS.forEach(componentName => {
+  CARD_COMPONENTS.forEach(componentName => {
     LAYOUTS.forEach(layout => {
       it(`Displays ${layout} for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
@@ -30,14 +22,10 @@ describe('Renders', () => {
           }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
-        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
-        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+        expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
+        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
       });
-    });
-  });
 
-  COMPONENTS.forEach(componentName => {
-    LAYOUTS.forEach(layout => {
       it(`Displays colon properly for ${layout} ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
           props = propsFactory.build({
@@ -48,10 +36,25 @@ describe('Renders', () => {
           tester = await new Tester(ComponentClass, { props }).mount();
 
         if (layout === 'vertical') {
-          expect(tester.find('.fields-ant-info-label-no-colon').length);
+          expect(tester.find('.fields-ant-info-label-no-colon').length).toBe(1);
         } else {
-          expect(tester.find('.fields-ant-info-label-colon').length);
+          expect(tester.find('.fields-ant-info-label-colon').length).toBe(1);
         }
+      });
+    });
+  });
+
+  FORM_COMPONENTS.forEach(componentName => {
+    LAYOUTS.forEach(layout => {
+      it(`Displays ${layout} for ${componentName}`, async () => {
+        const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
+          props = propsFactory.build({
+            fieldSets,
+            layout,
+          }),
+          tester = await new Tester(ComponentClass, { props }).mount();
+
+        expect(tester.find(`form.ant-form-${layout}`).length).toBe(1);
       });
     });
   });
@@ -67,14 +70,13 @@ describe('Renders', () => {
           tester = await new Tester(ComponentClass, { props }).mount();
 
         expect(isForm(tester)).toBe(false);
-        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
-        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+        expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
+        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
 
         tester.click(`button.btn-edit`);
 
         expect(isForm(tester)).toBe(true);
-        expect(tester.find(`.fields-ant-info-row-${layout}`).length);
-        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length);
+        expect(tester.find(`form.ant-form-${layout}`).length).toBe(1);
       });
     });
   });


### PR DESCRIPTION
Restructure fields-ant to support left-right label-data display
- Card objects can display label-data vertically or inline with the optional `display` prop [`"horizontal"`, `"vertical"`, or `"inline"`]
- Card objects can display a `:` postfixed to the label with the optional `colon` prop [`boolean`]
- Form objects can display label-data vertically or inline with the optional `display` prop [`"horizontal"`, `"vertical"`, or `"inline"`]
- Form objects can display a `:` postfixed to the label with the optional `colon` prop [`boolean`]
- Defaults for Card is `"vertical"` and Form label-data display is `"horizontal"` (this is currently how it is on our app)
- `"horizontal"` is equivalent to the default non-form Card objects

### Screenshots:

Card left/right:
<img width="1706" alt="Screen Shot 2021-02-24 at 4 55 26 PM" src="https://user-images.githubusercontent.com/46094451/109070916-1d767400-76c1-11eb-8163-414c742efe1a.png">
<img width="1863" alt="Screen Shot 2021-02-24 at 4 55 16 PM" src="https://user-images.githubusercontent.com/46094451/109070922-1f403780-76c1-11eb-8c4f-63251f7e1bbb.png">


Card vertical:
<img width="1562" alt="Screen Shot 2021-02-24 at 4 53 34 PM" src="https://user-images.githubusercontent.com/46094451/109070728-dbe5c900-76c0-11eb-9553-b7caf814c4e0.png">
<img width="1764" alt="Screen Shot 2021-02-24 at 4 53 22 PM" src="https://user-images.githubusercontent.com/46094451/109070738-df795000-76c0-11eb-93f3-3357eb4f28fb.png">

Form left/right:
<img width="497" alt="Screen Shot 2021-02-24 at 4 46 16 PM" src="https://user-images.githubusercontent.com/46094451/109070016-fbc8bd00-76bf-11eb-8bca-27d880a71af6.png">

Form vertical:
<img width="647" alt="Screen Shot 2021-02-24 at 4 45 34 PM" src="https://user-images.githubusercontent.com/46094451/109070000-f8353600-76bf-11eb-92a3-cd7ad6d8ce35.png">

Colon options:
<img width="180" alt="Screen Shot 2021-02-26 at 9 37 47 AM" src="https://user-images.githubusercontent.com/46094451/109313546-570cc380-7816-11eb-9873-6e72d4979cb7.png">
<img width="199" alt="Screen Shot 2021-02-26 at 9 37 59 AM" src="https://user-images.githubusercontent.com/46094451/109313551-583df080-7816-11eb-8ddb-13bfeab5400f.png">
<img width="337" alt="Screen Shot 2021-02-25 at 9 02 46 AM" src="https://user-images.githubusercontent.com/46094451/109313579-5e33d180-7816-11eb-9946-9f4ba0a5068d.png">
