### PR TITLE
Match layout features to ant-design's form

### DIFF
--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -79,8 +79,13 @@
   color: black;
 }
 
+.fields-ant-info-row-horizontal {
+  display: flex;
+}
+
 .fields-ant-info-row-inline {
   display: flex;
+  margin-right: 18px;
 }
 
 .fields-ant-info-label {
@@ -101,4 +106,18 @@
 
 .fields-ant-info-label-no-colon > label {
   margin-right: 8px;
+}
+
+.fields-ant-field-set-row-inline {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.fields-ant-form-item-horizontal {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.fields-ant-form-item-horizontal > .ant-form-item-control-wrapper {
+  flex: auto;
 }

--- a/src/building-blocks/CardFieldSet.tsx
+++ b/src/building-blocks/CardFieldSet.tsx
@@ -34,7 +34,7 @@ class CardFieldSet extends Component<ICardFieldSetProps> {
     }
 
     return (
-      <FieldSet fieldSet={fieldSet}>
+      <FieldSet fieldSet={fieldSet} {...passDownProps}>
         {filteredFieldConfigs.map(fieldConfig => (
           <CardField {...passDownProps} fieldConfig={fieldConfig} key={fieldConfig.field} model={model} />
         ))}

--- a/src/building-blocks/FieldSet.tsx
+++ b/src/building-blocks/FieldSet.tsx
@@ -6,15 +6,17 @@ import { ClassValue } from 'classnames/types';
 
 import * as Antd from 'antd';
 
-import { IFieldSetPartial } from '../interfaces';
+import { IFieldSetPartial, ILayout } from '../interfaces';
 import { isPartialFieldSetSimple } from '../utilities';
 import { CLASS_PREFIX } from '../consts';
 
 import Legend from './Legend';
+import { sharedComponentPropsDefaults } from '../propsDefaults';
 
 interface IProps {
   className?: ClassValue;
   fieldSet: IFieldSetPartial;
+  layout?: ILayout;
 }
 
 const CLASS_NAME = `${CLASS_PREFIX}-field-set`;
@@ -22,13 +24,15 @@ const CLASS_NAME = `${CLASS_PREFIX}-field-set`;
 @autoBindMethods
 @observer
 export default class FieldSet extends Component<IProps> {
+  public static defaultProps: Partial<IProps> = { ...sharedComponentPropsDefaults };
+
   public render() {
-    const { className, fieldSet } = this.props,
+    const { className, fieldSet, layout } = this.props,
       rowProps = !isPartialFieldSetSimple(fieldSet) && fieldSet.rowProps;
 
     return (
       <div className={cx(CLASS_NAME, className)}>
-        <Antd.Row {...rowProps}>
+        <Antd.Row {...rowProps} className={`${CLASS_NAME}-row-${layout}`}>
           <Legend fieldSet={fieldSet} />
 
           {this.props.children}

--- a/src/building-blocks/FormField.tsx
+++ b/src/building-blocks/FormField.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
-import { omit } from 'lodash';
 
 import { FormManager, fillInFieldConfig, filterFieldConfig } from '../utilities';
 import { IFieldConfigPartial } from '../interfaces';
@@ -57,12 +56,7 @@ class FormField extends Component<IFormFieldProps> {
     }
 
     return (
-      <FormItem
-        fieldConfig={this.fieldConfig}
-        formManager={formManager}
-        formModel={formModel}
-        {...omit(passDownProps, ['fieldConfig'])}
-      >
+      <FormItem {...passDownProps} fieldConfig={this.fieldConfig} formManager={formManager} formModel={formModel}>
         <EditComponent {...this.editProps} />
       </FormItem>
     );

--- a/src/building-blocks/FormField.tsx
+++ b/src/building-blocks/FormField.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import autoBindMethods from 'class-autobind-decorator';
+import { omit } from 'lodash';
 
 import { FormManager, fillInFieldConfig, filterFieldConfig } from '../utilities';
 import { IFieldConfigPartial } from '../interfaces';
@@ -48,15 +49,20 @@ class FormField extends Component<IFormFieldProps> {
       return null;
     }
 
-    const { formManager, formModel, fieldConfig, ...passDownProps } = this.props,
-      { skipFieldDecorator, editComponent: EditComponent } = fieldConfig;
+    const { formManager, formModel, ...passDownProps } = this.props,
+      { skipFieldDecorator, editComponent: EditComponent } = this.fieldConfig;
 
     if (skipFieldDecorator) {
       return <EditComponent {...this.editProps} />;
     }
 
     return (
-      <FormItem fieldConfig={this.fieldConfig} formManager={formManager} formModel={formModel} {...passDownProps}>
+      <FormItem
+        fieldConfig={this.fieldConfig}
+        formManager={formManager}
+        formModel={formModel}
+        {...omit(passDownProps, ['fieldConfig'])}
+      >
         <EditComponent {...this.editProps} />
       </FormItem>
     );

--- a/src/building-blocks/FormField.tsx
+++ b/src/building-blocks/FormField.tsx
@@ -48,15 +48,15 @@ class FormField extends Component<IFormFieldProps> {
       return null;
     }
 
-    const { formManager, formModel } = this.props,
-      { skipFieldDecorator, editComponent: EditComponent } = this.fieldConfig;
+    const { formManager, formModel, fieldConfig, ...passDownProps } = this.props,
+      { skipFieldDecorator, editComponent: EditComponent } = fieldConfig;
 
     if (skipFieldDecorator) {
       return <EditComponent {...this.editProps} />;
     }
 
     return (
-      <FormItem fieldConfig={this.fieldConfig} formManager={formManager} formModel={formModel}>
+      <FormItem fieldConfig={this.fieldConfig} formManager={formManager} formModel={formModel} {...passDownProps}>
         <EditComponent {...this.editProps} />
       </FormItem>
     );

--- a/src/building-blocks/FormFieldSet.tsx
+++ b/src/building-blocks/FormFieldSet.tsx
@@ -26,7 +26,7 @@ class FormFieldSet extends Component<IFormFieldSetProps> {
   }
 
   public render() {
-    const { formModel, fieldSet, formManager } = this.props,
+    const { formModel, fieldSet, formManager, ...passDownProps } = this.props,
       fieldConfigs = getFieldSetFields(this.fieldSet),
       filteredFieldConfigs = filterFieldConfigs(fieldConfigs, { model: formModel, readOnly: true });
 
@@ -35,13 +35,14 @@ class FormFieldSet extends Component<IFormFieldSetProps> {
     }
 
     return (
-      <FieldSet fieldSet={fieldSet}>
+      <FieldSet fieldSet={fieldSet} {...passDownProps}>
         {filteredFieldConfigs.map(fieldConfig => (
           <FormField
             fieldConfig={fieldConfig}
             formManager={formManager}
             formModel={formModel}
             key={fieldConfig.field}
+            {...passDownProps}
           />
         ))}
       </FieldSet>

--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -8,14 +8,16 @@ import * as Antd from 'antd';
 import { ValidationRule as AntValidationRule } from 'antd/es/form';
 
 import { FormManager, noopValidator, renderLabel } from '../utilities';
-import { IFieldConfig, IFieldsValidator } from '../interfaces';
+import { IFieldConfig, IFieldsValidator, ILayout } from '../interfaces';
 import { IModel } from '../props';
 import { CLASS_PREFIX } from '../consts';
+import { sharedComponentPropsDefaults } from '../propsDefaults';
 
 export interface IFormFieldProps {
   fieldConfig: IFieldConfig;
   formManager: FormManager;
   formModel: IModel;
+  layout?: ILayout;
 }
 
 export const FORM_ITEM_CLASS_NAME = `${CLASS_PREFIX}-form-item`;
@@ -23,6 +25,8 @@ export const FORM_ITEM_CLASS_NAME = `${CLASS_PREFIX}-form-item`;
 @autoBindMethods
 @observer
 class FormItem extends Component<IFormFieldProps> {
+  public static defaultProps: Partial<IFormFieldProps> = { ...sharedComponentPropsDefaults };
+
   private get initialValue() {
     const { formManager, fieldConfig } = this.props;
     return formManager.getDefaultValue(fieldConfig);
@@ -93,9 +97,14 @@ class FormItem extends Component<IFormFieldProps> {
   }
 
   public render() {
-    const { formManager, fieldConfig } = this.props,
+    const { formManager, fieldConfig, layout } = this.props,
       { colProps, formItemProps, field } = fieldConfig,
-      className = cx(FORM_ITEM_CLASS_NAME, fieldConfig.className, formItemProps && formItemProps.className),
+      className = cx(
+        FORM_ITEM_CLASS_NAME,
+        fieldConfig.className,
+        formItemProps && formItemProps.className,
+        `${FORM_ITEM_CLASS_NAME}-${layout}`,
+      ),
       { getFieldDecorator } = formManager.form;
 
     return (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -95,14 +95,21 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
       formModel = this.formManager.formModel,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel }),
       hasColon = !(colon === false || layout === 'vertical'),
-      className = cx(CLASS_NAME, this.props.className, `fields-ant-form${hasColon ? '' : '-no'}-colon`);
+      className = cx(CLASS_NAME, this.props.className, `${CLASS_NAME}${hasColon ? '' : '-no'}-colon`),
+      passDownProps = { layout: layout };
 
     return (
       <Antd.Form className={className} colon={colon} layout={layout} onSubmit={this.formManager.onSave}>
         {title && <h2>{title}</h2>}
 
         {filteredFieldSets.map((fieldSet, idx) => (
-          <FormFieldSet fieldSet={fieldSet} formManager={this.formManager} formModel={formModel} key={idx} />
+          <FormFieldSet
+            fieldSet={fieldSet}
+            formManager={this.formManager}
+            formModel={formModel}
+            key={idx}
+            {...passDownProps}
+          />
         ))}
 
         {this.props.children}

--- a/stories/3_features.stories.tsx
+++ b/stories/3_features.stories.tsx
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 
 import { EditableCard, FormCard, IFieldConfigObjectSearchCreate } from '../src';
 import { withInfoConfigured } from '../.storybook/config';
-import { objectSearchCreateFactory, formCardPropsFactory, fieldFactory } from '../test/factories';
+import { objectSearchCreateFactory, formCardPropsFactory, fieldFactory, stringFactory } from '../test/factories';
 import { ColProps } from 'antd/es/grid';
 import { IModel } from '../src/props';
 
@@ -12,6 +12,11 @@ storiesOf('Features', module)
   .addDecorator(withInfoConfigured)
   .add('display', () => (
     <>
+      <FormCard
+        {...formCardPropsFactory.build()}
+        layout='horizontal'
+        fieldSets={[[stringFactory.build(), stringFactory.build(), stringFactory.build()]]}
+      />
       <FormCard
         {...formCardPropsFactory.build()}
         layout="inline"

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -15,13 +15,12 @@ describe('Renders', () => {
   CARD_COMPONENTS.forEach(componentName => {
     it(`defaults ${componentName} correctly`, async () => {
       const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-        props = propsFactory.build({
-          fieldSets,
-        }),
+        props = propsFactory.build({ fieldSets }),
         tester = await new Tester(ComponentClass, { props }).mount();
 
-      expect(tester.find(`div.fields-ant-info-row-vertical`).length).toBe(1);
-      expect(tester.find(`.fields-ant-info-label-layout-vertical`).length).toBe(1);
+      expect(tester.find('div.fields-ant-info-row-vertical').length).toBe(1);
+      expect(tester.find('div.fields-ant-field-set-row-vertical').length).toBe(1);
+      expect(tester.find('.fields-ant-info-label-layout-vertical').length).toBe(1);
       expect(tester.find('.fields-ant-info-label-no-colon').length).toBe(1);
     });
   });
@@ -29,13 +28,13 @@ describe('Renders', () => {
   FORM_COMPONENTS.forEach(componentName => {
     it(`defaults ${componentName} correctly`, async () => {
       const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-        props = propsFactory.build({
-          fieldSets,
-        }),
+        props = propsFactory.build({ fieldSets }),
         tester = await new Tester(ComponentClass, { props }).mount();
 
-      expect(tester.find(`form.ant-form-vertical`).length).toBe(1);
+      expect(tester.find('form.ant-form-vertical').length).toBe(1);
       expect(tester.find('form.fields-ant-form-no-colon').length).toBe(1);
+      expect(tester.find('div.fields-ant-field-set-row-vertical').length).toBe(1);
+      expect(tester.find('div.fields-ant-form-item-vertical').length).toBe(1);
     });
   });
 
@@ -43,23 +42,17 @@ describe('Renders', () => {
     LAYOUTS.forEach(layout => {
       it(`Displays ${layout} for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-          props = propsFactory.build({
-            fieldSets,
-            layout,
-          }),
+          props = propsFactory.build({ fieldSets, layout }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
         expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
         expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
       });
 
       it(`Displays colon properly for ${layout} ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-          props = propsFactory.build({
-            fieldSets,
-            layout,
-            colon: true,
-          }),
+          props = propsFactory.build({ fieldSets, layout, colon: true }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
         if (layout === 'vertical') {
@@ -75,22 +68,17 @@ describe('Renders', () => {
     LAYOUTS.forEach(layout => {
       it(`Displays ${layout} for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-          props = propsFactory.build({
-            fieldSets,
-            layout,
-          }),
+          props = propsFactory.build({ fieldSets, layout }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
         expect(tester.find(`form.ant-form-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-form-item-${layout}`).length).toBe(1);
       });
 
       it(`Displays colon properly for ${layout} ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-          props = propsFactory.build({
-            fieldSets,
-            layout,
-            colon: true,
-          }),
+          props = propsFactory.build({ fieldSets, layout, colon: true }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
         if (layout === 'vertical') {
@@ -106,20 +94,20 @@ describe('Renders', () => {
     LAYOUTS.forEach(layout => {
       it(`Displays ${layout} when reading and writing for ${componentName}`, async () => {
         const { ComponentClass, propsFactory } = COMPONENT_GENERATORS[componentName],
-          props = propsFactory.build({
-            fieldSets,
-            layout,
-          }),
+          props = propsFactory.build({ fieldSets, layout }),
           tester = await new Tester(ComponentClass, { props }).mount();
 
         expect(isForm(tester)).toBe(false);
         expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
         expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
 
         tester.click(`button.btn-edit`);
 
         expect(isForm(tester)).toBe(true);
         expect(tester.find(`form.ant-form-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
+        expect(tester.find(`div.fields-ant-form-item-${layout}`).length).toBe(1);
       });
     });
   });


### PR DESCRIPTION
Updated the `horizontal` and `inline` `layout` options to reflect that of ant design's [Form](https://ant.design/components/form/) `layout` options.

Patch for [MTY-3412](https://thatsmighty.atlassian.net/browse/MTY-3412)

### Screenshots:
All screenshots are of a form component with no row/col props and completely unformatted. Only differences are layout types

**Vertical [default]:**
<img width="1286" alt="Screen Shot 2021-03-04 at 9 56 55 AM" src="https://user-images.githubusercontent.com/46094451/109982937-5ff70c80-7cd0-11eb-9207-f4d04577e643.png">

**Horizontal:**
<img width="1289" alt="Screen Shot 2021-03-04 at 9 56 21 AM" src="https://user-images.githubusercontent.com/46094451/109982963-64bbc080-7cd0-11eb-9857-ab0467a3cddf.png">

**Inline:**
<img width="1279" alt="Screen Shot 2021-03-04 at 9 56 43 AM" src="https://user-images.githubusercontent.com/46094451/109982973-671e1a80-7cd0-11eb-9ce4-4449a32b77d3.png">
