### PR TITLE
Add form class names for colon

### DIFF
--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import * as Antd from 'antd';
 import { ValidationRule as AntValidationRule } from 'antd/es/form';
 
-import { FormManager, noopValidator, renderLabel } from '../utilities';
+import { formatClassNames, FormManager, noopValidator, renderLabel } from '../utilities';
 import { IFieldConfig, IFieldsValidator, ILayout } from '../interfaces';
 import { IModel } from '../props';
 import { CLASS_PREFIX } from '../consts';
@@ -100,13 +100,11 @@ class FormItem extends Component<IFormFieldProps> {
   public render() {
     const { formManager, fieldConfig, layout, colon } = this.props,
       { colProps, formItemProps, field } = fieldConfig,
-      hasColon = !(colon === false || layout === 'vertical'),
       className = cx(
         FORM_ITEM_CLASS_NAME,
         fieldConfig.className,
         formItemProps && formItemProps.className,
-        `${FORM_ITEM_CLASS_NAME}-${layout}`,
-        `${FORM_ITEM_CLASS_NAME}${hasColon ? '' : '-no'}-colon`,
+        formatClassNames(FORM_ITEM_CLASS_NAME, colon, layout),
       ),
       { getFieldDecorator } = formManager.form;
 

--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -106,7 +106,7 @@ class FormItem extends Component<IFormFieldProps> {
         fieldConfig.className,
         formItemProps && formItemProps.className,
         `${FORM_ITEM_CLASS_NAME}-${layout}`,
-        `${FORM_ITEM_CLASS_NAME}${hasColon ? '' : '-no'}-colon`
+        `${FORM_ITEM_CLASS_NAME}${hasColon ? '' : '-no'}-colon`,
       ),
       { getFieldDecorator } = formManager.form;
 

--- a/src/building-blocks/FormItem.tsx
+++ b/src/building-blocks/FormItem.tsx
@@ -18,6 +18,7 @@ export interface IFormFieldProps {
   formManager: FormManager;
   formModel: IModel;
   layout?: ILayout;
+  colon?: boolean;
 }
 
 export const FORM_ITEM_CLASS_NAME = `${CLASS_PREFIX}-form-item`;
@@ -97,13 +98,15 @@ class FormItem extends Component<IFormFieldProps> {
   }
 
   public render() {
-    const { formManager, fieldConfig, layout } = this.props,
+    const { formManager, fieldConfig, layout, colon } = this.props,
       { colProps, formItemProps, field } = fieldConfig,
+      hasColon = !(colon === false || layout === 'vertical'),
       className = cx(
         FORM_ITEM_CLASS_NAME,
         fieldConfig.className,
         formItemProps && formItemProps.className,
         `${FORM_ITEM_CLASS_NAME}-${layout}`,
+        `${FORM_ITEM_CLASS_NAME}${hasColon ? '' : '-no'}-colon`
       ),
       { getFieldDecorator } = formManager.form;
 

--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -9,13 +9,15 @@ import * as Antd from 'antd';
 
 import { CLASS_PREFIX } from '../consts';
 import { IFieldConfigPartial, IFormatProps } from '../interfaces';
+import { formatClassNames } from '../utilities';
 
 @autoBindMethods
 @observer
-class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IFormatProps }> {
+class Info extends Component<{ fieldConfig: IFieldConfigPartial; format: IFormatProps }> {
   public render() {
-    const { format } = this.props,
-      layout = format && format.layout,
+    const {
+        format: { layout },
+      } = this.props,
       rowClassName = `${CLASS_PREFIX}-info-row-${layout}`;
 
     return (
@@ -28,19 +30,14 @@ class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IForma
 
 @autoBindMethods
 @observer
-class Label extends Component<{ className?: ClassValue; format?: IFormatProps }> {
+class Label extends Component<{ className?: ClassValue; format: IFormatProps }> {
   public render() {
-    const { className, format } = this.props,
-      colon = format && format.colon,
-      layout = format && format.layout,
-      // colon can be displayed only when layout is inline or horizontal
-      hasColon = !(colon === false || layout === 'vertical'),
-      labelClassName = cx(
+    const {
         className,
-        `${CLASS_PREFIX}-info-label`,
-        `${CLASS_PREFIX}-info-label${hasColon ? '' : '-no'}-colon`,
-        `${CLASS_PREFIX}-info-label-layout-${layout}`,
-      );
+        format: { layout, colon },
+      } = this.props,
+      infoLabelClassName = `${CLASS_PREFIX}-info-label`,
+      labelClassName = cx(className, infoLabelClassName, formatClassNames(infoLabelClassName, colon, layout));
 
     return (
       <div className={labelClassName}>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -11,7 +11,7 @@ import { FormComponentProps } from 'antd/es/form';
 
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
 import FormFieldSet from '../building-blocks/FormFieldSet';
-import { fillInFieldSets, filterFieldSets, FormManager } from '../utilities';
+import { fillInFieldSets, filterFieldSets, formatClassNames, FormManager } from '../utilities';
 import { formPropsDefaults, sharedComponentPropsDefaults } from '../propsDefaults';
 import { ISharedFormProps, ISharedComponentProps } from '../props';
 import { CLASS_PREFIX } from '../consts';
@@ -94,9 +94,8 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
     const { showControls, title, layout, colon } = this.props,
       formModel = this.formManager.formModel,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel }),
-      hasColon = !(colon === false || layout === 'vertical'),
-      className = cx(CLASS_NAME, this.props.className, `${CLASS_NAME}${hasColon ? '' : '-no'}-colon`),
-      passDownProps = { layout: layout, colon: colon };
+      className = cx(CLASS_NAME, this.props.className, formatClassNames(CLASS_NAME, colon, layout)),
+      passDownProps = { layout, colon };
 
     return (
       <Antd.Form className={className} colon={colon} layout={layout} onSubmit={this.formManager.onSave}>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -96,7 +96,7 @@ export class UnwrappedForm extends Component<IFormWrappedProps> {
       filteredFieldSets = filterFieldSets(this.fieldSets, { model: formModel }),
       hasColon = !(colon === false || layout === 'vertical'),
       className = cx(CLASS_NAME, this.props.className, `${CLASS_NAME}${hasColon ? '' : '-no'}-colon`),
-      passDownProps = { layout: layout };
+      passDownProps = { layout: layout, colon: colon };
 
     return (
       <Antd.Form className={className} colon={colon} layout={layout} onSubmit={this.formManager.onSave}>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,5 @@
+import { ILayout } from './interfaces';
+
 export const DEFAULT_DEBOUNCE_WAIT = 300;
 
 export const REGEXP_SSN = /^[0-9]{3}[-\s]?[0-9]{2}[-\s]?[0-9]{4}$/;
@@ -13,3 +15,9 @@ export const CLASS_PREFIX = 'fields-ant';
 export const ANT_FULL_COL_WIDTH = 24;
 
 export const TOAST_DURATION = 10;
+
+export const LAYOUT_TYPES: { [key: string]: ILayout } = {
+  HORIZONTAL: 'horizontal',
+  INLINE: 'inline',
+  VERTICAL: 'vertical',
+};

--- a/src/utilities/common.tsx
+++ b/src/utilities/common.tsx
@@ -13,10 +13,11 @@ import {
   IFieldSetSimple,
   IFieldSetSimplePartial,
   IInjected,
+  ILayout,
   IOption,
 } from '../interfaces';
 
-import { ID_ATTR } from '../consts';
+import { ID_ATTR, LAYOUT_TYPES } from '../consts';
 import { IModel, IValue } from '../props';
 import { isTypeAddress } from '../inputs/Address';
 import { isTypeObjectSearchCreate } from '../inputs/ObjectSearchCreate';
@@ -196,4 +197,9 @@ export function getBtnClassName(action: string, classNameSuffix?: string, title?
   return cx(prefix, isString(title) && `${prefix}-${kebabCase(title)}`, {
     [`${prefix}-${classNameSuffix}`]: !!classNameSuffix,
   });
+}
+
+export function formatClassNames(className: string, colon: boolean = false, layout: ILayout = LAYOUT_TYPES.VERTICAL) {
+  const hasColon = colon && layout !== LAYOUT_TYPES.VERTICAL;
+  return cx(`${className}-${layout}`, `${className}${hasColon ? '' : '-no'}-colon`);
 }

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -83,8 +83,10 @@ describe('Renders', () => {
 
         if (layout === 'vertical') {
           expect(tester.find('form.fields-ant-form-no-colon').length).toBe(1);
+          expect(tester.find('div.fields-ant-form-item-no-colon').length).toBe(1);
         } else {
           expect(tester.find('form.fields-ant-form-colon').length).toBe(1);
+          expect(tester.find('div.fields-ant-form-item-colon').length).toBe(1);
         }
       });
     });

--- a/test/features/labelDataDisplay.test.ts
+++ b/test/features/labelDataDisplay.test.ts
@@ -20,7 +20,7 @@ describe('Renders', () => {
 
       expect(tester.find('div.fields-ant-info-row-vertical').length).toBe(1);
       expect(tester.find('div.fields-ant-field-set-row-vertical').length).toBe(1);
-      expect(tester.find('.fields-ant-info-label-layout-vertical').length).toBe(1);
+      expect(tester.find('.fields-ant-info-label-vertical').length).toBe(1);
       expect(tester.find('.fields-ant-info-label-no-colon').length).toBe(1);
     });
   });
@@ -47,7 +47,7 @@ describe('Renders', () => {
 
         expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
         expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
-        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
+        expect(tester.find(`.fields-ant-info-label-${layout}`).length).toBe(1);
       });
 
       it(`Displays colon properly for ${layout} ${componentName}`, async () => {
@@ -102,7 +102,7 @@ describe('Renders', () => {
         expect(isForm(tester)).toBe(false);
         expect(tester.find(`div.fields-ant-info-row-${layout}`).length).toBe(1);
         expect(tester.find(`div.fields-ant-field-set-row-${layout}`).length).toBe(1);
-        expect(tester.find(`.fields-ant-info-label-layout-${layout}`).length).toBe(1);
+        expect(tester.find(`.fields-ant-info-label-${layout}`).length).toBe(1);
 
         tester.click(`button.btn-edit`);
 


### PR DESCRIPTION
Add `className` for colon on `formItem`. This is a requirement to add styles in registry.

Patch for [MTY-3412](https://thatsmighty.atlassian.net/browse/MTY-3412)
