### PR TITLE
Add card border property

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -9,9 +9,11 @@ import * as Antd from 'antd';
 import { fillInFieldSets, filterFieldSets } from '../utilities';
 import CardFieldSet from '../building-blocks/CardFieldSet';
 import { ISharedComponentProps } from '../props';
+import { cardPropsDefaults } from '../propsDefaults';
 import { CLASS_PREFIX } from '../consts';
 
 export interface ICardProps extends ISharedComponentProps {
+  bordered?: boolean;
   renderTopRight?: () => any;
 }
 
@@ -20,17 +22,20 @@ const CLASS_NAME = `${CLASS_PREFIX}-card`;
 @autoBindMethods
 @observer
 class Card extends Component<ICardProps> {
+  public static defaultProps: Partial<ICardProps> = { ...cardPropsDefaults };
+
   @computed
   private get fieldSets() {
     return fillInFieldSets(this.props.fieldSets);
   }
 
   public render() {
-    const { className, title, renderTopRight, isLoading, model, ...passDownProps } = this.props,
+    const { bordered, className, title, renderTopRight, isLoading, model, ...passDownProps } = this.props,
       filteredFieldSets = filterFieldSets(this.fieldSets, { model, writeOnly: true });
 
     return (
       <Antd.Card
+        bordered={bordered}
         className={cx(CLASS_NAME, className)}
         extra={renderTopRight && renderTopRight()}
         loading={isLoading}

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import * as Antd from 'antd';
 
 import { CLASS_PREFIX } from '../consts';
-import { formPropsDefaults } from '../propsDefaults';
+import { cardPropsDefaults, formPropsDefaults } from '../propsDefaults';
 import { ISharedFormProps } from '../props';
 
 import { ICardProps } from './Card';
@@ -20,15 +20,22 @@ export interface IFormCardProps extends ISharedFormProps, ICardProps {}
 export class FormCard extends Component<IFormCardProps> {
   public static defaultProps: Partial<IFormCardProps> = {
     ...formPropsDefaults,
+    ...cardPropsDefaults,
   };
 
   public render() {
-    const { className, isLoading, title, renderTopRight } = this.props,
+    const { bordered, className, isLoading, title, renderTopRight } = this.props,
       cardClassName = cx(`${CLASS_PREFIX}-card`, className),
       HANDLED_PROPS = ['title', 'renderTopRight'];
 
     return (
-      <Antd.Card className={cardClassName} loading={isLoading} title={title} extra={renderTopRight && renderTopRight()}>
+      <Antd.Card
+        bordered={bordered}
+        className={cardClassName}
+        loading={isLoading}
+        title={title}
+        extra={renderTopRight && renderTopRight()}
+      >
         <Form {...omit(this.props, HANDLED_PROPS)} />
       </Antd.Card>
     );

--- a/src/propsDefaults.ts
+++ b/src/propsDefaults.ts
@@ -12,6 +12,10 @@ export const formPropsDefaults = {
   saveText: 'Save',
 };
 
+export const cardPropsDefaults = {
+  bordered: true,
+};
+
 export const sharedComponentPropsDefaults: { layout?: ILayout; colon: boolean } = {
   layout: 'vertical',
   colon: false,


### PR DESCRIPTION
Allow boolean border property to be added to any `Card` type. Default is bordered.