### PR TITLE
Inlcude custom className for info row (read view) on form

### DIFF
--- a/dist/fieldsAnt.cjs.js
+++ b/dist/fieldsAnt.cjs.js
@@ -2872,7 +2872,7 @@ var Info = autoBindMethods(_class$g = mobxReact.observer(_class$g = /*#__PURE__*
       return /*#__PURE__*/React__default.createElement(Antd.Col, _extends({}, this.props.fieldConfig.colProps, {
         className: "".concat(CLASS_PREFIX, "-info")
       }), /*#__PURE__*/React__default.createElement(Antd.Row, {
-        className: rowClassName
+        className: cx(rowClassName, fieldConfig.className)
       }, this.props.children));
     }
   }]);


### PR DESCRIPTION
This PR adds the field `className` to read view of the form items.