### PR TITLE
Include className in read view of form that was reverted in release 1.6.8

### DIFF
--- a/dist/fieldsAnt.cjs.js
+++ b/dist/fieldsAnt.cjs.js
@@ -4209,7 +4209,7 @@ var Info = autoBindMethods(_class$g = mobxReact.observer(_class$g = /*#__PURE__*
       return /*#__PURE__*/React__default.createElement(Antd.Col, _extends({}, this.props.fieldConfig.colProps, {
         className: "".concat(CLASS_PREFIX, "-info")
       }), /*#__PURE__*/React__default.createElement(Antd.Row, {
-        className: rowClassName
+        className: cx(rowClassName, fieldConfig.className)
       }, this.props.children));
     }
   }]);


### PR DESCRIPTION
For some reason, this change has been reverted in this release commit: https://github.com/mighty-justice/fields-ant/commit/aae5bc1e75f1b1e9951d8591dd4e199540dac034