### PR TITLE
Use custom className for info view

### DIFF
--- a/src/building-blocks/Info.tsx
+++ b/src/building-blocks/Info.tsx
@@ -17,8 +17,7 @@ class Info extends Component<{ fieldConfig: IFieldConfigPartial; format?: IForma
   public render() {
     const { fieldConfig, format } = this.props,
       layout = format?.layout,
-      customClassName = fieldConfig.className,
-      rowClassName = cx(customClassName, `${CLASS_PREFIX}-info-row-${layout}`);
+      rowClassName = cx(fieldConfig.className, `${CLASS_PREFIX}-info-row-${layout}`);
 
     return (
       <Col {...this.props.fieldConfig.colProps} className={`${CLASS_PREFIX}-info`}>


### PR DESCRIPTION
This was never really implemented in https://github.com/mighty-justice/fields-ant/pull/413 nor https://github.com/mighty-justice/fields-ant/pull/418 due to the change being made in `dist` folder.