### PR TITLE
Make argument for formManager's onFinish optional

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -267,7 +267,7 @@ class FormManager {
     this.notifyUserAboutErrors(backendErrors.errorMessages);
   }
 
-  public async onFinish(_values: any) {
+  public async onFinish() {
     const { onSave } = this.args;
     this.isSaving = true;
 


### PR DESCRIPTION
Make argument for `formManager`'s `onFinish` function optional. This causes errors in the Registry where `onFinish` is called without any arguments