### PR TITLE
Fix: objectSearchCreate input id

### DIFF
--- a/src/inputs/ObjectSearchCreate.tsx
+++ b/src/inputs/ObjectSearchCreate.tsx
@@ -162,6 +162,7 @@ class ObjectSearchCreate extends Component<IObjectSearchCreateProps> {
           addNewContent={addNewContent}
           debounceWait={debounceWait}
           fieldConfig={fieldConfig}
+          id={fieldConfig.field}
           isOptionDisabled={isOptionDisabled}
           loadingIcon={loadingIcon}
           noSearchContent={noSearchContent}

--- a/test/types/objectSearch.test.ts
+++ b/test/types/objectSearch.test.ts
@@ -65,7 +65,7 @@ export async function objectSearchFor(tester: any, field: string, results: any, 
   tester.endpoints['/legal-organizations/'] = { results };
 
   // Change input without blurring
-  const input = tester.find(`input#${field}`).first();
+  const input = tester.find(`input[id="${field}"]`).first();
   await act(async () => {
     input.simulate('focus');
     input.simulate('change', { target: { value: searchTerm } });

--- a/test/types/objectSearchCreate.test.ts
+++ b/test/types/objectSearchCreate.test.ts
@@ -63,6 +63,17 @@ async function clickBack(tester: any) {
 }
 
 describe('objectSearchCreate', () => {
+  it('Renders input correctly', async () => {
+    const { field, props } = getDefaults({ field: 'lawfirm.plaintiff' }),
+      tester = new Tester(FormCard, { props });
+
+    await act(async () => {
+      await tester.mount();
+    });
+
+    expect(tester.find(`input[id="${field}"]`).length).toBe(1);
+  });
+
   it('Selects existing', async () => {
     const { field, props, onSave, searchTerm, results } = getDefaults({}),
       tester = new Tester(FormCard, { props });


### PR DESCRIPTION
Add `id` prop to all implementations of `ObjectSearch` + add test case