### PR TITLE
Fix: Date validation test act errors

### DIFF
--- a/test/types/date.test.ts
+++ b/test/types/date.test.ts
@@ -14,9 +14,12 @@ async function checkInferYear(newYear: string) {
     onSave = jest.fn(),
     props = { fieldSets, model, onSave };
 
-  const tester = await new Tester(FormCard, { props }).mount();
-  await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, newYear);
-  await tester.submit();
+  const tester = new Tester(FormCard, { props });
+  await act(async () => {
+    await tester.mount();
+    await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, newYear);
+    await tester.submit();
+  });
   return onSave.mock.calls[0][0][fieldConfig.field].slice(0, 4);
 }
 
@@ -30,12 +33,12 @@ async function isInputsValid(month: string, day: string, year: string) {
   const tester = new Tester(FormCard, { props });
   await act(async () => {
     await tester.mount();
+    await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, month);
+    await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, day);
+    await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, year);
+    await tester.refresh();
+    await tester.submit();
   });
-  await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, month);
-  await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, day);
-  await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, year);
-  await tester.refresh();
-  await tester.submit();
   return !!onSave.mock.calls.length;
 }
 
@@ -54,9 +57,12 @@ describe('date', () => {
       onSave = jest.fn(),
       props = { fieldSets, model, onSave };
 
-    const tester = await new Tester(FormCard, { props }).mount();
-    await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, newDay);
-    await tester.submit();
+    const tester = new Tester(FormCard, { props });
+    await act(async () => {
+      await tester.mount();
+      await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, newDay);
+      await tester.submit();
+    });
     expect(onSave).toHaveBeenCalledWith({ [fieldConfig.field]: newValue });
   });
 
@@ -99,16 +105,19 @@ describe('date', () => {
       onSave = jest.fn(),
       props = { fieldSets, onSave, required: false };
 
-    const tester = await new Tester(FormCard, { props }).mount();
+    const tester = new Tester(FormCard, { props });
 
-    await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '01');
-    await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '01');
-    await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '2019');
+    await act(async () => {
+      await tester.mount();
+      await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '01');
+      await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '01');
+      await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '2019');
 
-    await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '');
-    await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '');
-    await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '');
-    await tester.submit();
+      await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, '');
+      await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, '');
+      await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, '');
+      await tester.submit();
+    });
 
     expect(!!onSave.mock.calls.length).toBe(true);
   });

--- a/test/types/date.test.ts
+++ b/test/types/date.test.ts
@@ -1,4 +1,6 @@
+import { act } from 'react-dom/test-utils';
 import faker from 'faker';
+
 import { Tester } from '@mighty-justice/tester';
 
 import { FormCard } from '../../src';
@@ -25,7 +27,10 @@ async function isInputsValid(month: string, day: string, year: string) {
     onSave = jest.fn(),
     props = { fieldSets, onSave };
 
-  const tester = await new Tester(FormCard, { props }).mount();
+  const tester = new Tester(FormCard, { props });
+  await act(async () => {
+    await tester.mount();
+  });
   await tester.changeInput(`input[id="${fieldConfig.field}.month"]`, month);
   await tester.changeInput(`input[id="${fieldConfig.field}.day"]`, day);
   await tester.changeInput(`input[id="${fieldConfig.field}.year"]`, year);


### PR DESCRIPTION
This is an attempt to fix the `jest.setTimeout.Error` on the `date.test.ts`'s `validate` test when trying to deploy a new version

<img width="1395" alt="Screen Shot 2021-11-22 at 11 25 04 AM" src="https://user-images.githubusercontent.com/46094451/142899622-0cba6256-8927-40a8-bae1-dad149a43b0c.png">

This is the first of two ideas to fix the issue:
1) Fix act errors
2) Add a default timeout for that particular test to give a greater buffer (maybe 10000ms)

**Note:** only the contents of [this pr](https://github.com/mighty-justice/fields-ant/pull/449) have been changed since the last version `v1.8.2`