### PR TITLE
Add collapsible prop to editable array card

### DIFF
--- a/src/components/EditableArrayCard.tsx
+++ b/src/components/EditableArrayCard.tsx
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash';
 import autoBindMethods from 'class-autobind-decorator';
 import SmartBool from '@mighty-justice/smart-bool';
 
-import { Card } from 'antd';
+import { Card, Collapse } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 
 import GuardedButton from '../building-blocks/GuardedButton';
@@ -18,9 +18,11 @@ import FormCard from './FormCard';
 import { IArrayCardProps } from './ArrayCard';
 
 export interface IEditableArrayCardProps extends IArrayCardProps, ISharedFormProps {
+  collapsible?: boolean;
   defaults?: object;
   onCreate: (model: unknown) => Promise<any>;
   onDelete?: (model: unknown) => Promise<any>;
+  panelHeader?: string;
 }
 
 @autoBindMethods
@@ -60,18 +62,60 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
     );
   }
 
-  public render() {
+  private renderCard(modelItem: any) {
     const {
       classNameSuffix,
+      fieldSets,
+      onDelete,
+      onSave,
+      onSuccess,
+      ...passDownProps
+    } = this.props;
+
+    return (
+      <EditableCard
+        {...passDownProps}
+        classNameSuffix={classNameSuffix}
+        fieldSets={fieldSets}
+        key={modelItem.id}
+        model={modelItem}
+        onDelete={onDelete}
+        onSave={onSave}
+        onSuccess={onSuccess}
+        title=""
+      />
+    )
+  }
+
+  private renderEditableCards() {
+    const { collapsible, model, panelHeader } = this.props;
+
+    if (collapsible) {
+      return (
+        <Collapse defaultActiveKey={['1']}>
+          {model.map((modelItem: any, index: number) => {
+            const header = panelHeader? modelItem[panelHeader] : null;
+
+            return (
+              <Collapse.Panel header={header} key={index + 1}>
+                {this.renderCard(modelItem)}
+              </Collapse.Panel>
+            )
+          })}
+        </Collapse>
+      )
+    }
+
+    return model.map((modelItem: any) => this.renderCard(modelItem));
+  }
+
+  public render() {
+    const {
       defaults,
       fieldSets,
       isLoading,
       model,
-      onDelete,
-      onSave,
-      onSuccess,
       title,
-      ...passDownProps
     } = this.props;
 
     return (
@@ -87,20 +131,7 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
         )}
 
         {isEmpty(model) && !this.isAddingNew.isTrue && <p className="empty-message">No records</p>}
-
-        {model.map(modelItem => (
-          <EditableCard
-            {...passDownProps}
-            classNameSuffix={classNameSuffix}
-            fieldSets={fieldSets}
-            key={modelItem.id}
-            model={modelItem}
-            onDelete={onDelete}
-            onSave={onSave}
-            onSuccess={onSuccess}
-            title=""
-          />
-        ))}
+        {this.renderEditableCards()}
       </Card>
     );
   }

--- a/src/components/EditableArrayCard.tsx
+++ b/src/components/EditableArrayCard.tsx
@@ -63,14 +63,7 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
   }
 
   private renderCard(modelItem: any) {
-    const {
-      classNameSuffix,
-      fieldSets,
-      onDelete,
-      onSave,
-      onSuccess,
-      ...passDownProps
-    } = this.props;
+    const { classNameSuffix, fieldSets, onDelete, onSave, onSuccess, ...passDownProps } = this.props;
 
     return (
       <EditableCard
@@ -84,7 +77,7 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
         onSuccess={onSuccess}
         title=""
       />
-    )
+    );
   }
 
   private renderEditableCards() {
@@ -94,29 +87,23 @@ class EditableArrayCard extends Component<IEditableArrayCardProps> {
       return (
         <Collapse defaultActiveKey={['1']}>
           {model.map((modelItem: any, index: number) => {
-            const header = panelHeader? modelItem[panelHeader] : null;
+            const header = panelHeader ? modelItem[panelHeader] : null;
 
             return (
               <Collapse.Panel header={header} key={index + 1}>
                 {this.renderCard(modelItem)}
               </Collapse.Panel>
-            )
+            );
           })}
         </Collapse>
-      )
+      );
     }
 
     return model.map((modelItem: any) => this.renderCard(modelItem));
   }
 
   public render() {
-    const {
-      defaults,
-      fieldSets,
-      isLoading,
-      model,
-      title,
-    } = this.props;
+    const { defaults, fieldSets, isLoading, model, title } = this.props;
 
     return (
       <Card title={title} extra={this.renderAddNew()} loading={isLoading}>

--- a/test/components/EditableArrayCard.test.ts
+++ b/test/components/EditableArrayCard.test.ts
@@ -96,17 +96,17 @@ describe('EditableArrayCard', () => {
   it('Renders first item in collapsible component', async () => {
     const tester = await new Tester(EditableArrayCard, { props: { ...props, collapsible: true } }).mount();
 
-    expect(tester.html()).toContain(model[0].id)
-    expect(tester.html()).toContain(model[0].name)
-  })
+    expect(tester.html()).toContain(model[0].id);
+    expect(tester.html()).toContain(model[0].name);
+  });
 
   it('Renders only panel headers of collapsed items', async () => {
-    const tester = await new Tester(EditableArrayCard, { props: { ...props, collapsible: true } }).mount()
-    , collapsedItems = model.slice(1);
+    const tester = await new Tester(EditableArrayCard, { props: { ...props, collapsible: true } }).mount(),
+      collapsedItems = model.slice(1);
 
     collapsedItems.forEach(item => {
       expect(tester.html()).toContain(item.name);
       expect(tester.html()).not.toContain(item.id);
     });
-  })
+  });
 });

--- a/test/components/EditableArrayCard.test.ts
+++ b/test/components/EditableArrayCard.test.ts
@@ -15,12 +15,14 @@ const title = faker.lorem.sentence(),
   onCreate = jest.fn(),
   onSave = jest.fn(),
   onSuccess = jest.fn(),
-  fieldSets = [[{ field: 'name' }]],
+  fieldSets = [[{ field: 'id' }, { field: 'name' }]],
+  panelHeader = 'name',
   props = {
     fieldSets,
     model,
     onCreate,
     onSave,
+    panelHeader,
     title,
   };
 
@@ -57,7 +59,7 @@ describe('EditableArrayCard', () => {
 
     await fillOutAndSubmit(tester, 'new', newValue);
 
-    expect(onCreate).toHaveBeenCalledWith({ name: newValue });
+    expect(onCreate).toHaveBeenCalledWith({ name: newValue, id: '' });
 
     await tester.refresh();
     expect(tester.find('input#name').length).toBe(0);
@@ -90,4 +92,21 @@ describe('EditableArrayCard', () => {
     await tester.refresh();
     expect(tester.find('input#name').length).toBe(0);
   });
+
+  it('Renders first item in collapsible component', async () => {
+    const tester = await new Tester(EditableArrayCard, { props: { ...props, collapsible: true } }).mount();
+
+    expect(tester.html()).toContain(model[0].id)
+    expect(tester.html()).toContain(model[0].name)
+  })
+
+  it('Renders only panel headers of collapsed items', async () => {
+    const tester = await new Tester(EditableArrayCard, { props: { ...props, collapsible: true } }).mount()
+    , collapsedItems = model.slice(1);
+
+    collapsedItems.forEach(item => {
+      expect(tester.html()).toContain(item.name);
+      expect(tester.html()).not.toContain(item.id);
+    });
+  })
 });


### PR DESCRIPTION
The Jira ticket linked below states: "Ideally, past evaluations would be collapsed by default but expandable."

This PR modifies the `EditableArrayCard` component to allow for a `collapsible` prop. This determines whether the editable cards are rendered as usual, or as collapsible items within a `Collapse` component:

![Screen Shot 2022-04-25 at 5 30 06 PM](https://user-images.githubusercontent.com/46462400/165195704-70e5cbcf-fa10-45e9-ab5b-b5e6e2db3e33.png)

By default, only the first item is shown and the others are collapsed (which means only the panel headers are rendered until the item is expanded).

Jira: https://thatsmighty.atlassian.net/browse/PROD-878?atlOrigin=eyJpIjoiZWY5NWI4ZTg5NTgxNDI2ODgxMTUwNGNjOTc5MWYzOGEiLCJwIjoiaiJ9