### PR TITLE
Do not disable cancel button if disabled prop is true

### DIFF
--- a/src/utilities/FormManager.ts
+++ b/src/utilities/FormManager.ts
@@ -108,7 +108,7 @@ class FormManager {
   }
 
   public get isCancelButtonDisabled(): boolean {
-    return this.isFormDisabled;
+    return this.isSaving;
   }
 
   public getDefaultValue(fieldConfig: IFieldConfig): IValue {


### PR DESCRIPTION
# Description
- The `disabled` prop should probably only affect the submit button
- I think the only time we'd really want to disable the cancel button is when the form is saving

**JIRA**: https://thatsmighty.atlassian.net/browse/PROD-1533

**QA**: https://mighty.testpad.com/script/168#49// (0039-0043)