### PR TITLE
Add option to disable delete button if model has protected object

### DIFF
--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -21,9 +21,9 @@ import FormModal from './FormModal';
 
 export interface IEditableCardProps extends ICardProps, ISharedFormProps {
   ModalComponent?: new (props: ISharedFormModalProps) => FormModal | FormDrawer;
-  deleteDisabledTooltip?: string;
+  disabledDeleteTooltip?: string;
   onDelete?: (model: unknown) => Promise<any>;
-  protectedField?: string | null;
+  disableDelete?: (model: unknown) => boolean;
 }
 
 @autoBindMethods
@@ -34,8 +34,8 @@ class EditableCard extends Component<IEditableCardProps> {
 
   public static defaultProps = {
     ...formPropsDefaults,
-    deleteDisabledTooltip: '',
-    protectedField: null,
+    disabledDeleteTooltip: '',
+    disableDelete: () => false,
   };
 
   private async handleDelete() {
@@ -70,27 +70,27 @@ class EditableCard extends Component<IEditableCardProps> {
     const {
         isGuarded,
         classNameSuffix,
-        deleteDisabledTooltip,
+        disabledDeleteTooltip,
+        disableDelete,
         isLoading,
         model,
         onDelete,
-        protectedField,
         title,
       } = this.props,
       className = getBtnClassName('delete', classNameSuffix, title),
-      hasProtectedObject = protectedField ? !!model && model[protectedField].length : false;
+      isDeleteDisabled = disableDelete && disableDelete(model);
 
     if (!onDelete) {
       return null;
     }
-
+    
     return (
-      <Tooltip title={hasProtectedObject ? deleteDisabledTooltip : ''}>
+      <Tooltip title={isDeleteDisabled ? disabledDeleteTooltip : ''}>
         <span>
           <GuardedButton
             className={className}
             confirm={true}
-            disabled={hasProtectedObject || isLoading || this.isDeleting.isTrue}
+            disabled={isDeleteDisabled || isLoading || this.isDeleting.isTrue}
             icon={<DeleteOutlined />}
             isGuarded={isGuarded}
             onClick={this.handleDelete}

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -67,7 +67,16 @@ class EditableCard extends Component<IEditableCardProps> {
   }
 
   private get deleteButton() {
-    const { isGuarded, classNameSuffix, deleteDisabledTooltip,  isLoading, model, onDelete, protectedField, title } = this.props,
+    const {
+        isGuarded,
+        classNameSuffix,
+        deleteDisabledTooltip,
+        isLoading,
+        model,
+        onDelete,
+        protectedField,
+        title,
+      } = this.props,
       className = getBtnClassName('delete', classNameSuffix, title),
       hasProtectedObject = protectedField ? !!model && model[protectedField].length : false;
 
@@ -78,18 +87,18 @@ class EditableCard extends Component<IEditableCardProps> {
     return (
       <Tooltip title={hasProtectedObject ? deleteDisabledTooltip : ''}>
         <span>
-        <GuardedButton
-          className={className}
-          confirm={true}
-          disabled={hasProtectedObject || isLoading || this.isDeleting.isTrue}
-          icon={<DeleteOutlined />}
-          isGuarded={isGuarded}
-          onClick={this.handleDelete}
-          size="small"
-          type="danger"
-        >
-          Delete
-        </GuardedButton>
+          <GuardedButton
+            className={className}
+            confirm={true}
+            disabled={hasProtectedObject || isLoading || this.isDeleting.isTrue}
+            icon={<DeleteOutlined />}
+            isGuarded={isGuarded}
+            onClick={this.handleDelete}
+            size="small"
+            type="danger"
+          >
+            Delete
+          </GuardedButton>
         </span>
       </Tooltip>
     );

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -5,6 +5,7 @@ import autoBindMethods from 'class-autobind-decorator';
 
 import SmartBool from '@mighty-justice/smart-bool';
 
+import { Tooltip } from 'antd';
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 
 import ButtonToolbar from '../building-blocks/ButtonToolbar';
@@ -20,8 +21,9 @@ import FormModal from './FormModal';
 
 export interface IEditableCardProps extends ICardProps, ISharedFormProps {
   ModalComponent?: new (props: ISharedFormModalProps) => FormModal | FormDrawer;
-  isDeleteDisabled?: boolean;
+  deleteDisabledTooltip?: string;
   onDelete?: (model: unknown) => Promise<any>;
+  protectedField?: string | null;
 }
 
 @autoBindMethods
@@ -32,7 +34,8 @@ class EditableCard extends Component<IEditableCardProps> {
 
   public static defaultProps = {
     ...formPropsDefaults,
-    isDeleteDisabled: false,
+    deleteDisabledTooltip: '',
+    protectedField: null,
   };
 
   private async handleDelete() {
@@ -64,26 +67,31 @@ class EditableCard extends Component<IEditableCardProps> {
   }
 
   private get deleteButton() {
-    const { isDeleteDisabled, isGuarded, classNameSuffix, onDelete, isLoading, title } = this.props,
-      className = getBtnClassName('delete', classNameSuffix, title);
+    const { isGuarded, classNameSuffix, deleteDisabledTooltip,  isLoading, model, onDelete, protectedField, title } = this.props,
+      className = getBtnClassName('delete', classNameSuffix, title),
+      hasProtectedObject = protectedField ? !!model && model[protectedField].length : false;
 
     if (!onDelete) {
       return null;
     }
 
     return (
-      <GuardedButton
-        className={className}
-        confirm={true}
-        disabled={isDeleteDisabled || isLoading || this.isDeleting.isTrue}
-        icon={<DeleteOutlined />}
-        isGuarded={isGuarded}
-        onClick={this.handleDelete}
-        size="small"
-        type="danger"
-      >
-        Delete
-      </GuardedButton>
+      <Tooltip title={hasProtectedObject ? deleteDisabledTooltip : ''}>
+        <span>
+        <GuardedButton
+          className={className}
+          confirm={true}
+          disabled={hasProtectedObject || isLoading || this.isDeleting.isTrue}
+          icon={<DeleteOutlined />}
+          isGuarded={isGuarded}
+          onClick={this.handleDelete}
+          size="small"
+          type="danger"
+        >
+          Delete
+        </GuardedButton>
+        </span>
+      </Tooltip>
     );
   }
 

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -20,10 +20,10 @@ import FormDrawer from './FormDrawer';
 import FormModal from './FormModal';
 
 export interface IEditableCardProps extends ICardProps, ISharedFormProps {
-  ModalComponent?: new (props: ISharedFormModalProps) => FormModal | FormDrawer;
   disabledDeleteTooltip?: string;
-  onDelete?: (model: unknown) => Promise<any>;
   disableDelete?: (model: unknown) => boolean;
+  ModalComponent?: new (props: ISharedFormModalProps) => FormModal | FormDrawer;
+  onDelete?: (model: unknown) => Promise<any>;
 }
 
 @autoBindMethods

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -20,6 +20,7 @@ import FormModal from './FormModal';
 
 export interface IEditableCardProps extends ICardProps, ISharedFormProps {
   ModalComponent?: new (props: ISharedFormModalProps) => FormModal | FormDrawer;
+  isDeleteDisabled?: boolean;
   onDelete?: (model: unknown) => Promise<any>;
 }
 
@@ -31,6 +32,7 @@ class EditableCard extends Component<IEditableCardProps> {
 
   public static defaultProps = {
     ...formPropsDefaults,
+    isDeleteDisabled: false,
   };
 
   private async handleDelete() {
@@ -62,7 +64,7 @@ class EditableCard extends Component<IEditableCardProps> {
   }
 
   private get deleteButton() {
-    const { isGuarded, classNameSuffix, onDelete, isLoading, title } = this.props,
+    const { isDeleteDisabled, isGuarded, classNameSuffix, onDelete, isLoading, title } = this.props,
       className = getBtnClassName('delete', classNameSuffix, title);
 
     if (!onDelete) {
@@ -73,7 +75,7 @@ class EditableCard extends Component<IEditableCardProps> {
       <GuardedButton
         className={className}
         confirm={true}
-        disabled={isLoading || this.isDeleting.isTrue}
+        disabled={isDeleteDisabled || isLoading || this.isDeleting.isTrue}
         icon={<DeleteOutlined />}
         isGuarded={isGuarded}
         onClick={this.handleDelete}

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -68,10 +68,10 @@ class EditableCard extends Component<IEditableCardProps> {
 
   private get deleteButton() {
     const {
-        isGuarded,
         classNameSuffix,
         disabledDeleteTooltip,
         disableDelete,
+        isGuarded,
         isLoading,
         model,
         onDelete,

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -83,7 +83,7 @@ class EditableCard extends Component<IEditableCardProps> {
     if (!onDelete) {
       return null;
     }
-    
+
     return (
       <Tooltip title={isDeleteDisabled ? disabledDeleteTooltip : ''}>
         <span>

--- a/test/components/EditableCard.test.ts
+++ b/test/components/EditableCard.test.ts
@@ -62,7 +62,7 @@ describe('EditableCard', () => {
     expect(onDelete).toHaveBeenCalled();
   });
 
-  it('Disables delete and shows tooltip', async () => {
+  it('Can disable delete', async () => {
     const onDelete = jest.fn().mockResolvedValue({}),
       props = {
         ...editableCardPropsFactory.build(),

--- a/test/components/EditableCard.test.ts
+++ b/test/components/EditableCard.test.ts
@@ -61,4 +61,20 @@ describe('EditableCard', () => {
     await tester.click('.btn-delete .ant-popover-inner .ant-btn-primary');
     expect(onDelete).toHaveBeenCalled();
   });
+
+  it('Disables delete and shows tooltip', async () => {
+    const onDelete = jest.fn().mockResolvedValue({}),
+      props = {
+        ...editableCardPropsFactory.build(),
+        onDelete,
+        model: { protectedField: ['Protected Object'] },
+        protectedField: 'protectedField',
+      },
+      tester = await new Tester(EditableCard, { props }).mount();
+
+    await tester.click(`button.btn-delete`);
+    await tester.refresh();
+    expect(tester.find('.btn-delete .ant-popover-inner .ant-btn-primary').length).toBe(0);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
 });

--- a/test/components/EditableCard.test.ts
+++ b/test/components/EditableCard.test.ts
@@ -67,7 +67,7 @@ describe('EditableCard', () => {
       props = {
         ...editableCardPropsFactory.build(),
         onDelete,
-        disableDelete: (model) => model.protectedField.length, 
+        disableDelete: model => model.protectedField.length > 0,
         model: { protectedField: ['Protected Object'] },
       },
       tester = await new Tester(EditableCard, { props }).mount();

--- a/test/components/EditableCard.test.ts
+++ b/test/components/EditableCard.test.ts
@@ -67,8 +67,8 @@ describe('EditableCard', () => {
       props = {
         ...editableCardPropsFactory.build(),
         onDelete,
+        disableDelete: (model) => model.protectedField.length, 
         model: { protectedField: ['Protected Object'] },
-        protectedField: 'protectedField',
       },
       tester = await new Tester(EditableCard, { props }).mount();
 


### PR DESCRIPTION
**JIRA**: https://thatsmighty.atlassian.net/browse/PROD-506
CoOp pull request: https://github.com/mighty-justice/coop-client/pull/1198

Tested in Storybook (ended up removing the Storybook code, thought it might be overkill):
![Screenshot 2023-08-21 at 3 18 53 AM](https://github.com/mighty-justice/fields-ant/assets/52181740/dce964d3-ae61-4fea-89d7-18a2d1ed2181)

Also tested in CoOp:
![Screenshot 2023-08-21 at 3 28 12 AM](https://github.com/mighty-justice/fields-ant/assets/52181740/6b2205df-9af6-4c4e-ba7a-89ca84beaef4)